### PR TITLE
docs: install and run the pack on Codex, Cursor and Gemini CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ to change something, six rules cover it.
    treats it as read-only. `Write(path)` is not a rule Claude Code reads, use
    `Edit(path)`.
 
-Testing the hooks: `bash hooks/test.sh` puts both of them through eight
+Testing the hooks: `bash hooks/test.sh` puts both of them through nine
 scenarios in throwaway repositories, with a throwaway home directory, so it
 touches nothing of yours. Run one by hand instead and remember that both read
 from standard input: add `</dev/null` or they sit there waiting for a payload

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ in this repository, with notes on what the rewrite changed:
 
 ## Quick start
 
-You need Claude Code. This pack is built and tested for it and nothing else
-so far. `git` and `gh` are optional: a couple of the skills read project state
-through them, and without those tools more of the output honestly says "not
-checked".
+Claude Code is what the pack is built and measured on, and the only tool where
+everything works with no extra steps. The skills and the routing block also
+install into Codex, Cursor and Gemini CLI, see
+[Other agents](#other-agents-codex-cursor-gemini-cli) below. `git` and `gh` are
+optional: a couple of the skills read project state through them, and without
+those tools more of the output honestly says "not checked".
 
 Clone this repository:
 
@@ -111,6 +113,35 @@ To update: `claude plugin update open-steps`. To remove:
 The one piece that stays manual is the writing style, because turning it on
 would silently replace whatever style you already chose. Two lines, in
 [`docs/output-style.md`](docs/output-style.md).
+
+## Other agents: Codex, Cursor, Gemini CLI
+
+Codex, Cursor and Gemini CLI all read `~/.agents/skills/`, so one command
+installs the pack into all three. Run it from the folder holding the clone:
+
+```bash
+mkdir -p ~/.agents/skills && cp -R open-steps/skills/os-* ~/.agents/skills/
+```
+
+Then the routing block goes into whatever that tool treats as your standing
+instructions, doing the same job it does in `CLAUDE.md` above:
+
+| Tool | Routing block goes in | Evidence |
+|---|---|---|
+| Codex | `~/.codex/AGENTS.md` | checked, on Codex CLI 0.145 |
+| Cursor | `AGENTS.md` in the project root | Cursor's documentation |
+| Gemini CLI | `~/.gemini/GEMINI.md` | Gemini CLI's documentation |
+
+The hooks are the part that differs per tool. Codex runs both of them
+unchanged, with a short block in `~/.codex/config.toml` and one trust prompt to
+accept. Cursor
+and Gemini CLI want JSON where these two print text, so both need an adapter
+that is not written yet, and on Cursor a stop cannot be blocked at all. On
+both, the skills and the routing block install; how reliably the skills fire
+there is not checked.
+
+The commands, the paths, the Codex hook config, and what was run rather than
+read: [`docs/other-agents.md`](docs/other-agents.md).
 
 ## The skills
 

--- a/docs/claude-md.md
+++ b/docs/claude-md.md
@@ -34,6 +34,10 @@ Reports live in `~/.claude/open-steps/reports/<project>/`. Read `latest.md`
 before re-exploring a repository you have worked in before.
 ```
 
+On another agent the same block goes in that agent's own instructions file
+instead. [`docs/other-agents.md`](other-agents.md) has the file and the command
+for each, and the hooks below are a separate matter on those tools.
+
 ## Why this is required and not a nicety
 
 A skill is **model-invoked**: the agent decides whether to load it. Two of these

--- a/docs/other-agents.md
+++ b/docs/other-agents.md
@@ -1,0 +1,198 @@
+# Running the pack on Codex, Cursor and Gemini CLI
+
+Claude Code is what the pack is built and measured on. Everything here is the
+second-best case: the skills carry over cleanly, the routing block carries over
+cleanly, the hooks carry over on one other tool and not yet on the rest.
+
+What was run is marked as run. Everything else comes from a vendor's
+documentation and is called out where it matters. Same rule the skills follow.
+
+## The skills
+
+A skill is a folder with a `SKILL.md` in it, and that format is now shared
+across tools. Codex, Cursor and Gemini CLI all read one folder,
+`~/.agents/skills/`, so a single command installs the pack into all three. Run
+it from the folder holding the clone, the one that contains `open-steps/`:
+
+```bash
+mkdir -p ~/.agents/skills && cp -R open-steps/skills/os-* ~/.agents/skills/
+```
+
+Copies, so run it again after a `git pull` to update.
+
+Linking instead works and updates itself, but it renames the skills. Codex
+resolves a symlink back to the clone and takes the namespace from the folder
+it lands in, so `ln -sfn "$PWD"/open-steps/skills/os-* ~/.agents/skills/`
+produces `open-steps:os-done-or-not` where a copy produces `os-done-or-not`.
+The routing block uses the short names. Copy unless there is a reason not to.
+
+Each tool also has its own folder, should the shared one ever be a problem:
+`~/.codex/skills/`, `~/.cursor/skills/`, `~/.gemini/skills/`. Cursor also reads
+`~/.claude/skills/` and `~/.codex/skills/`, though behind a setting covered
+below. These per-tool paths come from each tool's documentation; the shared
+folder is the one that was run.
+
+## The routing block
+
+The block in [`routing-block.md`](routing-block.md) does the same job here as
+in `CLAUDE.md`: it turns six moments into an obligation rather than a hint.
+Skills are model-invoked everywhere, so this matters everywhere.
+
+One command per tool, from the folder holding the clone, safe to re-run:
+
+| Tool | File | Command |
+|---|---|---|
+| Codex | `~/.codex/AGENTS.md` | `mkdir -p ~/.codex && grep -q 'os-done-or-not' ~/.codex/AGENTS.md 2>/dev/null \|\| cat open-steps/docs/routing-block.md >> ~/.codex/AGENTS.md` |
+| Gemini CLI | `~/.gemini/GEMINI.md` | `mkdir -p ~/.gemini && grep -q 'os-done-or-not' ~/.gemini/GEMINI.md 2>/dev/null \|\| cat open-steps/docs/routing-block.md >> ~/.gemini/GEMINI.md` |
+| Cursor | `AGENTS.md` in the project root | `grep -q 'os-done-or-not' AGENTS.md 2>/dev/null \|\| cat open-steps/docs/routing-block.md >> AGENTS.md` |
+
+Cursor's is per project because Cursor has no global `AGENTS.md`. Per its
+documentation it reads `AGENTS.md` in the project root and in subdirectories,
+and keeps cross-project preferences in User Rules, which is a settings screen
+rather than a file this command can append to.
+
+## The hooks
+
+Here the tools stop agreeing. Both hooks are plain shell reading JSON on
+standard input, so the interesting question is what each tool does with what
+they return.
+
+| Tool | Session start | Stop |
+|---|---|---|
+| Claude Code | works, wired by the plugin | works, wired by the plugin |
+| Codex | works, script unchanged | works, script unchanged |
+| Cursor | needs a JSON wrapper | cannot block a stop at all |
+| Gemini CLI | needs a JSON wrapper | needs one too, on `AfterAgent` |
+
+### Codex
+
+Codex takes a `session_start` command hook's plain stdout as additional
+context, and treats exit code 2 from a `stop` hook as "blocked", with stderr as
+the reason. That is the same contract Claude Code uses, so both scripts run
+unmodified. Only the wiring changes: Codex configures hooks in TOML, and there
+is no `${CLAUDE_PLUGIN_ROOT}` outside a plugin, so the paths are absolute.
+
+Add to `~/.codex/config.toml`, replacing the path with your clone:
+
+```toml
+[[hooks.session_start]]
+[[hooks.session_start.hooks]]
+type = "command"
+command = "/absolute/path/to/open-steps/hooks/session-start.sh"
+timeout_sec = 10
+
+[[hooks.stop]]
+[[hooks.stop.hooks]]
+type = "command"
+command = "/absolute/path/to/open-steps/hooks/stop-report.sh"
+timeout_sec = 10
+```
+
+`codex doctor` reports `config.toml parse ok` when the shape is right.
+
+Then trust them, and this part is not optional. Codex reviews newly added hooks
+at startup and offers to trust them or to continue without trusting. A hook
+that is not trusted still runs, but loses its control effects, which is exactly
+the half that matters here: the stop hook's exit code 2 stops blocking and the
+report is never asked for, quietly. If reports never appear, this is the first
+thing to check.
+
+The same environment variables apply, because they are read by the scripts
+rather than by any tool: `OPEN_STEPS_COOLDOWN`, `OPEN_STEPS_MIN_FILES`,
+`OPEN_STEPS_MAX_REPOS`, `OPEN_STEPS_DISABLE`, `OPEN_STEPS_MAX_REPORT_LINES`,
+`OPEN_STEPS_NO_SESSION_START`.
+
+### Cursor
+
+Everything in this section is from Cursor's documentation. None of it was run.
+
+Cursor has the two events, `sessionStart` and `stop`, in
+`~/.cursor/hooks.json` or `<project>/.cursor/hooks.json`, shaped
+`{"version": 1, "hooks": {"sessionStart": [{"command": "..."}]}}`. They read
+JSON on stdin and must write JSON on stdout, where invalid JSON counts as a
+hook failure. So `session-start.sh` needs its handover wrapped as
+`{"additional_context": "..."}` rather than printed. Small adapter, not written
+yet.
+
+The stop side is a difference in kind rather than a wrapper. A `stop` hook
+cannot block. Its one documented output is `followup_message`, which Cursor
+submits as the next user message and then carries on, bounded by `loop_limit`.
+A Claude-style `{"decision": "block"}` is accepted but downgraded to exactly
+that. Exit code 2 does block, but only on the gate hooks, `preToolUse` and
+`beforeShellExecution` and their siblings, never on `stop`. A port would ask
+for the report through `followup_message` and would have to be tested on its
+own terms.
+
+One thing to check first if nothing loads at all: `~/.agents/skills/` is read
+directly, but the compatibility paths `~/.claude/skills/` and
+`~/.codex/skills/` sit behind Cursor's "Include third-party Plugins, Skills,
+and other configs" setting.
+
+### Gemini CLI
+
+Everything in this section is from Gemini CLI's documentation. None of it was
+run.
+
+Hooks live in `settings.json`, user-level `~/.gemini/settings.json` or
+project-level `.gemini/settings.json`, under a `hooks` object keyed by event
+name. They read JSON on stdin and must write JSON on stdout, and the
+documentation is blunt about it: a script must not print plain text to stdout
+other than the final JSON. So the same wrapper Cursor needs applies here with a
+different field name. `SessionStart` injects through
+`hookSpecificOutput.additionalContext`.
+
+The stop side needs the right event, and it is not the obvious one. `SessionEnd`
+fires when the CLI exits, is best effort, is not waited for, and has all its
+flow-control fields ignored, so a report can never be asked for from there.
+`AfterAgent` is the one that matches: it fires once per turn after the model's
+final response, and it does take `decision: "deny"` with a `reason`, where the
+reason is sent to the agent as a new prompt asking for a correction. That is
+the same shape as this pack's exit code 2 with the request on stderr.
+
+So both hooks can be ported here too. Neither is ported yet.
+
+### What those two lose
+
+Until someone does that work, both tools get the skills and the routing block,
+which is the part that changes what the agent says to you. What they lose is
+the report at the end of a session, and the previous report in front of the
+next one.
+
+## What was actually run
+
+On Codex CLI 0.145, in a throwaway home directory:
+
+```bash
+codex debug prompt-input | grep -o 'os-[a-z-]*' | sort -u
+```
+
+lists all six skill names, reaching the model with their descriptions intact.
+This is also where the symlink naming difference above turned up.
+
+Both hooks were then fed a Codex-shaped payload directly:
+
+```bash
+payload='{"session_id":"s1","cwd":"'"$PWD"'","model":"gpt-5","permission_mode":"default"}'
+printf '%s' "$payload" | hooks/session-start.sh    # prints the handover, exits 0
+printf '%s' "$payload" | hooks/stop-report.sh      # exits 2, report request on stderr
+```
+
+The second one needs an uncommitted change in the repository to have anything
+to report. `hooks/test.sh` covers this shape as CASE 9, so it stays covered.
+
+Not run: hooks firing inside a live Codex session, which needs a real turn
+rather than a rendered prompt. The trust step above is read from how Codex
+implements hooks, not from watching it happen. Not run at all: anything on
+Cursor or Gemini CLI. Their paths and contracts here come from their own
+documentation.
+
+## What does not come across
+
+- **Activation is measured on Claude models only.** The figures in the README
+  say nothing about how reliably these skills switch on inside another tool.
+  No figure is quoted for those because none was measured.
+- **`allowed-tools:` is Claude Code's field.** Other tools ignore it and ask
+  for permission the way they normally do. Safer, just chattier.
+- **Reports still land in `~/.claude/open-steps/reports/<project>/`.** The name
+  says Claude; it is only a path, and one folder means every tool reads the
+  same history.

--- a/hooks/test.sh
+++ b/hooks/test.sh
@@ -87,6 +87,18 @@ case "$out" in
   *) check "the baseline stays off stdout" 0 0 ;;
 esac
 
+echo "CASE 9  a payload from another agent, with fields these hooks do not know"
+# Codex and Gemini CLI send the same session_id inside a fuller payload. The
+# baseline is taken from a plain one and the stop reads the fuller one, so a
+# session id that failed to parse would fall back, stop matching, and this case
+# would go silent instead of asking. That is what makes it worth a case.
+H="$(mktemp -d)"; newrepo
+start S9
+echo change >> a.txt
+printf '{"session_id":"S9","cwd":"%s","transcript_path":null,"model":"gpt-5","permission_mode":"default"}' "$PWD" \
+  | HOME="$H" bash "$PACK/hooks/stop-report.sh" 2>/dev/null
+check "the session id is still found" 2 $?
+
 echo
 echo "passed $pass, failed $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Documentation, plus one test case. No skill file changes and neither hook
script changes.

## What this adds

The six skills already work outside Claude Code. `SKILL.md` is a shared format
now, and Codex, Cursor and Gemini CLI all read the same folder,
`~/.agents/skills/`, so the install is one command and the routing block from
`docs/routing-block.md` goes into that tool's own instructions file. That was
undocumented, so this documents it.

- `docs/other-agents.md` is new: paths, commands, the Codex hook config, and a
  per-tool table of what carries over.
- `README.md` gets a short section, and the Quick start line that said Claude
  Code and nothing else now points at it.
- `docs/claude-md.md` gets a pointer to the equivalent file per tool.
- `CONTRIBUTING.md` goes from eight scenarios to nine.
- `hooks/test.sh` gains CASE 9.

## The finding worth reviewing

**Both hooks run unmodified on Codex.** It takes a `session_start` hook's plain
stdout as additional context, and treats exit code 2 from a `stop` hook as
blocked with stderr as the reason. That is the contract this pack already
targets, so only the wiring differs: TOML in `~/.codex/config.toml` instead of
`hooks/hooks.json`, and absolute paths instead of `${CLAUDE_PLUGIN_ROOT}`.

With one catch that is in the doc because it fails silently. Codex reviews new
hooks at startup and offers to trust them or continue without trusting. An
untrusted hook still runs but loses its control effects, so the stop hook's
exit code 2 stops blocking, the report is never asked for, and nothing says
why.

Cursor and Gemini CLI both want JSON on stdout where these scripts print text,
so both need an adapter that is not written yet. It is written up with the
exact fields rather than left vague, so the next person has a map:

- Cursor: `additional_context` on `sessionStart`. A `stop` hook cannot block at
  all; the only output is `followup_message`, and a Claude-style
  `{"decision": "block"}` is accepted but quietly downgraded to that. Exit code
  2 blocks only on the gate hooks, never on `stop`.
- Gemini CLI: `hookSpecificOutput.additionalContext` on `SessionStart`. The
  stop side is `AfterAgent` with `decision: "deny"` and a `reason`, not the
  obvious `SessionEnd`, which is best effort and ignores flow control
  completely.

## CASE 9, and why it is not a green rubber stamp

Codex and Gemini CLI send the same `session_id` inside a fuller payload. The
new case takes the baseline from a plain payload and reads the stop from a
Codex-shaped one, so a session id that failed to parse would fall back, stop
matching, and the case would go silent instead of asking.

It was checked by mutation rather than by passing: replacing `os_session_id`
with a naive parser that breaks on extra fields leaves CASE 1 through CASE 8
green and fails only CASE 9.

## Checked

- `bash hooks/test.sh` - passed 12, failed 0
- `claude plugin validate .` - validation passed
- Codex CLI 0.145, throwaway home directory:
  `codex debug prompt-input | grep -o 'os-[a-z-]*' | sort -u` lists all six
  skills with descriptions intact
- Codex CLI 0.145: `codex doctor` reports `config.toml parse ok` for the hook
  config in `docs/other-agents.md`
- Both hook scripts fed a Codex-shaped payload by hand: session-start printed
  the handover and exited 0, stop exited 2 with the report request on stderr

## Not checked, and labelled as such in the file

- Hooks firing inside a live Codex session. The contract was checked from both
  ends, the join was not.
- Anything on Cursor or Gemini CLI. Their paths and contracts come from their
  own documentation.
- Activation rates on non-Claude models. No figure is quoted because none was
  measured.

## One side finding that changed the instructions

Installing the skills by symlink makes Codex resolve them back to the clone and
list them as `open-steps:os-done-or-not`, while the routing block uses the short
names. So the documented install copies, and the symlink variant is written
down with that caveat rather than recommended.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
