### PR TITLE
feat(skills): os-what-could-go-wrong, a premortem before you commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "open-steps",
       "source": "./",
-      "description": "Skills that make a Claude Code session legible to someone who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words."
+      "description": "Skills that make a Claude Code session legible to someone who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, a premortem that attacks a decision before it is locked in, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "open-steps",
       "source": "./",
-      "description": "Skills that make a Claude Code session legible to someone who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, a premortem that attacks a decision before it is locked in, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words."
+      "description": "Skills that keep development open to the person running it, who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, an attack on a decision while it can still be changed, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "open-steps",
-  "description": "Skills that make a Claude Code session legible to someone who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words.",
+  "description": "Skills that make a Claude Code session legible to someone who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, a premortem that attacks a decision before it is locked in, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words.",
   "version": "0.1.0",
   "license": "MIT",
   "keywords": [
     "claude-code",
     "agent-skills",
     "session-report",
+    "premortem",
     "plain-language",
     "orchestration"
   ],

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-steps",
   "description": "Skills that keep development open to the person running it, who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, an attack on a decision while it can still be changed, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "keywords": [
     "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-steps",
-  "description": "Skills that make a Claude Code session legible to someone who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, a premortem that attacks a decision before it is locked in, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words.",
+  "description": "Skills that keep development open to the person running it, who does not read code: plain-language session reports, followable operator instructions, decisions framed as questions with a recommendation, an attack on a decision while it can still be changed, what-to-do-next orchestration, verification of work done in other sessions, and on-demand restatement of any text in plain words.",
   "version": "0.1.0",
   "license": "MIT",
   "keywords": [

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ engineering.
 The pack tells the agent to separate what it measured from what it assumed.
 Same rule for me.
 
-Eighteen phrases a person would actually say, three of them per skill, each
-asked three times, headless, in a working installation, on three Claude
-models. The question every time: did the right skill switch on by itself?
+Eighteen phrases a person would actually say, three of them for each of the
+six skills that existed when this pass ran, each asked three times, headless,
+in a working installation, on three Claude models. The question every time: did the right skill switch on by itself?
 Three off-topic questions, each also asked three times, checked the opposite.
 
 ![Activation per skill on Haiku 4.5, Sonnet 5 and Opus 5](assets/activation.svg)
@@ -185,6 +185,12 @@ Three off-topic questions, each also asked three times, checked the opposite.
 | **All 18 phrases** | **79%** | **96%** | **100%** |
 | Fired on an off-topic question | 1/9 | 0/9 | 0/9 |
 
+`os-what-could-go-wrong` is missing from that table because it was added after
+the pass and has not been measured. Its three phrases are in
+[`cases.md`](evals/cases.md) waiting for the next run. Not checked is not the
+same as fine, and it is the skill most likely to compete with `os-ask-simple`
+for a phrase.
+
 The honest reading, because the misses matter more than the score.
 
 - On Sonnet 5 and Opus 5 this works. Three skills are perfect on every model.
@@ -199,8 +205,9 @@ The honest reading, because the misses matter more than the score.
   a secret on the server, tell me what to do", it wants to know which server
   and which secret. That is the pack's own earn-the-ask rule; a one-shot test
   scores it as a miss.
-- The test set is mine, and it is small. Eighteen phrases in a repository you
-  can read, so write better ones and re-run it.
+- The test set is mine, and it is small. Twenty-one phrases in a repository
+  you can read, eighteen of them measured, so write better ones and re-run
+  it.
 
 Two things earlier rounds cost me, kept here because they are the useful part.
 A negation inside a description ("this is NOT the skill for X") is ignored, so
@@ -219,7 +226,9 @@ another model.
 
 Also measured, and easy to check yourself: the skill descriptions cost **770
 tokens per session**, always on, which Claude Code reports itself with
-`claude plugin details open-steps`. The session-start hook adds its injection
+`claude plugin details open-steps`. That figure was taken before
+`os-what-could-go-wrong` was added and has not been retaken; run the command
+for the current one. The session-start hook adds its injection
 on top, capped by `OPEN_STEPS_MAX_REPORT_LINES`. Installing works from a
 clean empty account, with both hooks connected. `claude plugin validate
 --strict` passes.

--- a/README.md
+++ b/README.md
@@ -167,47 +167,52 @@ engineering.
 The pack tells the agent to separate what it measured from what it assumed.
 Same rule for me.
 
-Eighteen phrases a person would actually say, three of them for each of the
-six skills that existed when this pass ran, each asked three times, headless,
-in a working installation, on three Claude models. The question every time: did the right skill switch on by itself?
-Three off-topic questions, each also asked three times, checked the opposite.
+Twenty-one phrases a person would actually say, three per skill, each asked
+three times, headless, in a working installation, on three Claude models. The
+question every time: did the right skill switch on by itself? Three off-topic
+questions, each also asked three times, checked the opposite. Remeasured in
+full on 2026-08-29, the day the seventh skill landed.
 
 ![Activation per skill on Haiku 4.5, Sonnet 5 and Opus 5](assets/activation.svg)
 
 | Skill | Haiku 4.5 | Sonnet 5 | Opus 5 |
 |---|---|---|---|
 | `os-check-work` | 9/9 | 9/9 | 9/9 |
-| `os-done-or-not` | 9/9 | 9/9 | 9/9 |
 | `os-whats-next` | 9/9 | 9/9 | 9/9 |
-| `os-ask-simple` | 8/9 | 7/9 | 9/9 |
-| `os-say-simple` | 5/9 | 9/9 | 9/9 |
-| `os-step-by-step` | 3/9 | 9/9 | 9/9 |
-| **All 18 phrases** | **79%** | **96%** | **100%** |
+| `os-what-could-go-wrong` | 9/9 | 9/9 | 9/9 |
+| `os-ask-simple` | 9/9 | 8/9 | 9/9 |
+| `os-done-or-not` | 9/9 | 7/9 | 9/9 |
+| `os-say-simple` | 6/9 | 9/9 | 9/9 |
+| `os-step-by-step` | 4/9 | 9/9 | 9/9 |
+| **All 21 phrases** | **87%** | **95%** | **100%** |
 | Fired on an off-topic question | 1/9 | 0/9 | 0/9 |
-
-`os-what-could-go-wrong` is missing from that table because it was added after
-the pass and has not been measured. Its three phrases are in
-[`cases.md`](evals/cases.md) waiting for the next run. Not checked is not the
-same as fine, and it is the skill most likely to compete with `os-ask-simple`
-for a phrase.
 
 The honest reading, because the misses matter more than the score.
 
-- On Sonnet 5 and Opus 5 this works. Three skills are perfect on every model.
+- On Sonnet 5 and Opus 5 this works. Three skills are perfect on every model,
+  and Opus missed nothing at all.
+- `os-what-could-go-wrong` was named the skill most likely to steal a phrase
+  from `os-ask-simple`, so that was measured before it merged: 27/27 on its
+  own phrases, `os-ask-simple` did not drop, and off-topic questions still
+  leave it silent. The fear did not survive the measurement.
+- Sonnet 5 dropped two runs of the vaguest phrase ("That's it for today. What
+  happened?") to no skill at all, not to the new one. Asked six more times
+  the same way, it fired six of six. Read the 7/9 as the same run-to-run
+  wobble Haiku shows below; it stays in the table because that is what the
+  pass measured.
 - On Haiku 4.5, two skills are unreliable and one off-topic question wrongly
   pulled in a skill. If you run on the cheapest model, expect to type the
   skill name yourself sometimes.
-- Haiku also moves between runs. An earlier sweep of the same phrases put
-  `os-step-by-step` at 50% where this one puts it at 33%, and put false fires
-  at zero. Three runs per phrase is a smoke test, not a benchmark, and small
-  numbers wobble. I would rather say that than quote the friendlier sweep.
+- Haiku also moves between runs. Three sweeps of the same phrases have put
+  `os-step-by-step` at 50%, 33% and now 44%, and false fires at zero and one.
+  Three runs per phrase is a smoke test, not a benchmark, and small numbers
+  wobble. I would rather say that than quote the friendliest sweep.
 - Where Haiku misses, it usually asks a clarifying question first: told "put
   a secret on the server, tell me what to do", it wants to know which server
   and which secret. That is the pack's own earn-the-ask rule; a one-shot test
   scores it as a miss.
 - The test set is mine, and it is small. Twenty-one phrases in a repository
-  you can read, eighteen of them measured, so write better ones and re-run
-  it.
+  you can read, so write better ones and re-run it.
 
 Two things earlier rounds cost me, kept here because they are the useful part.
 A negation inside a description ("this is NOT the skill for X") is ignored, so

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ read: [`docs/other-agents.md`](docs/other-agents.md).
 | [`os-done-or-not`](skills/os-done-or-not/) | A one-screen report with a verdict: done or not, anything needed from you, any new debt, safe to close | Work wraps up, or you ask how it went |
 | [`os-step-by-step`](skills/os-step-by-step/) | Numbered steps a non-technical person can follow. The agent must first try everything itself and ask only for what truly needs you | The agent needs you to run, paste, click, approve or test something |
 | [`os-ask-simple`](skills/os-ask-simple/) | The question in plain words, what it costs later, and one marked recommendation | The agent has a question or options for you |
+| [`os-what-could-go-wrong`](skills/os-what-could-go-wrong/) | Assumes the decision already failed and works backwards to find out why, in a fresh agent that had no hand in it. Ends on one verdict | Something hard to undo is about to be agreed - a contract, a purchase, a migration, a launch |
 | [`os-whats-next`](skills/os-whats-next/) | Merges what is verified and ready, then recommends the next task and says why in plain words | You ask what is left or what to do next |
 | [`os-check-work`](skills/os-check-work/) | Does not trust another session's report. Checks every claim against what actually happened, then says what to do about it | Another session says it is done |
 | [`os-say-simple`](skills/os-say-simple/) | Rewrites any text in plain words without losing facts or bad news. Give it a number and you get exactly that many points | Any text reads like engineering: a report, a comment, an error, the agent's own answer |
@@ -157,7 +158,9 @@ read: [`docs/other-agents.md`](docs/other-agents.md).
 They work as a loop: `os-whats-next` picks the work, `os-step-by-step` walks
 you through your part, `os-done-or-not` reports the result, `os-check-work`
 accepts what other sessions did, `os-ask-simple` handles the questions on the
-way, and `os-say-simple` rescues any text that still reads like engineering.
+way, `os-what-could-go-wrong` attacks anything hard to undo before it is
+agreed, and `os-say-simple` rescues any text that still reads like
+engineering.
 
 ## Numbers
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ they survive uninstalling the pack.
 And the honest limits. Not every skill has a worked example yet.
 `os-whats-next` and `os-check-work` read project state through `git` and `gh`;
 without those tools, more of the output says "not checked". The writing style
-does not reach subagents.
+does not reach subagents; `os-what-could-go-wrong`, the only skill that
+dispatches one, carries its rules inside the handover instead, so its plain
+language rests on `references/premortem-prompt.md` alone.
 
 ## Open source
 

--- a/assets/activation.svg
+++ b/assets/activation.svg
@@ -1,14 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="920" height="584" viewBox="0 0 920 584" font-family="Helvetica, Arial, sans-serif">
-<rect width="920" height="584" fill="#FAF9F5"/>
-<rect x="20" y="20" width="880" height="544" rx="20" fill="#F5F4ED" stroke="#DFDDD4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="633" viewBox="0 0 920 633" font-family="Helvetica, Arial, sans-serif">
+<rect width="920" height="633" fill="#FAF9F5"/>
+<rect x="20" y="20" width="880" height="593" rx="20" fill="#F5F4ED" stroke="#DFDDD4"/>
 <text x="52" y="64" fill="#1F1E1D" font-size="24" font-weight="700">Did the right skill switch on by itself?</text>
-<text x="52" y="89" fill="#73726C" font-size="14">18 phrases &#183; 3 runs each &#183; headless install &#183; higher is better</text>
+<text x="52" y="89" fill="#73726C" font-size="14">21 phrases &#183; 3 runs each &#183; headless install &#183; higher is better</text>
 <rect x="52.0" y="116" width="261.3" height="64" rx="12" fill="#FFFFFF" stroke="#DFDDD4"/>
 <text x="108.2" y="153.0" fill="#5F5E59" font-size="15" font-weight="700">Haiku 4.5</text>
-<text x="210.2" y="156.0" fill="#1F1E1D" font-size="25" font-weight="700">79%</text>
+<text x="210.2" y="156.0" fill="#1F1E1D" font-size="25" font-weight="700">87%</text>
 <rect x="329.3" y="116" width="261.3" height="64" rx="12" fill="#FFFFFF" stroke="#DFDDD4"/>
 <text x="384.0" y="153.0" fill="#5F5E59" font-size="15" font-weight="700">Sonnet 5</text>
-<text x="489.0" y="156.0" fill="#1F1E1D" font-size="25" font-weight="700">96%</text>
+<text x="489.0" y="156.0" fill="#1F1E1D" font-size="25" font-weight="700">95%</text>
 <rect x="606.7" y="116" width="261.3" height="64" rx="12" fill="#FFFFFF" stroke="#DFDDD4"/>
 <text x="661.8" y="153.0" fill="#5F5E59" font-size="15" font-weight="700">Opus 5</text>
 <text x="750.8" y="156.0" fill="#1F1E1D" font-size="25" font-weight="700">100%</text>
@@ -24,44 +24,52 @@
 <text x="646" y="269.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="765" y="250.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="796" y="269.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
-<line x1="52" y1="289" x2="868" y2="289" stroke="#E2E0D8"/>
-<text x="52" y="318.5" fill="#1F1E1D" font-size="14" font-weight="600">os-done-or-not</text>
+<line x1="52" y1="289.0" x2="868" y2="289.0" stroke="#E2E0D8"/>
+<text x="52" y="318.5" fill="#1F1E1D" font-size="14" font-weight="600">os-whats-next</text>
 <rect x="465" y="299.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="496" y="318.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="615" y="299.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="646" y="318.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="765" y="299.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="796" y="318.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
-<line x1="52" y1="338" x2="868" y2="338" stroke="#E2E0D8"/>
-<text x="52" y="367.5" fill="#1F1E1D" font-size="14" font-weight="600">os-whats-next</text>
+<line x1="52" y1="338.0" x2="868" y2="338.0" stroke="#E2E0D8"/>
+<text x="52" y="367.5" fill="#1F1E1D" font-size="14" font-weight="600">os-what-could-go-wrong</text>
 <rect x="465" y="348.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="496" y="367.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="615" y="348.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="646" y="367.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="765" y="348.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="796" y="367.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
-<line x1="52" y1="387" x2="868" y2="387" stroke="#E2E0D8"/>
+<line x1="52" y1="387.0" x2="868" y2="387.0" stroke="#E2E0D8"/>
 <text x="52" y="416.5" fill="#1F1E1D" font-size="14" font-weight="600">os-ask-simple</text>
-<rect x="465" y="397.5" width="62" height="28" rx="14" fill="#C96F50" fill-opacity="0.14"/>
-<text x="496" y="416.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">8/9</text>
+<rect x="465" y="397.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
+<text x="496" y="416.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="615" y="397.5" width="62" height="28" rx="14" fill="#C96F50" fill-opacity="0.14"/>
-<text x="646" y="416.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">7/9</text>
+<text x="646" y="416.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">8/9</text>
 <rect x="765" y="397.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="796" y="416.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
-<line x1="52" y1="436" x2="868" y2="436" stroke="#E2E0D8"/>
-<text x="52" y="465.5" fill="#1F1E1D" font-size="14" font-weight="600">os-say-simple</text>
-<rect x="465" y="446.5" width="62" height="28" rx="14" fill="#C96F50" fill-opacity="0.14"/>
-<text x="496" y="465.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">5/9</text>
-<rect x="615" y="446.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
-<text x="646" y="465.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
+<line x1="52" y1="436.0" x2="868" y2="436.0" stroke="#E2E0D8"/>
+<text x="52" y="465.5" fill="#1F1E1D" font-size="14" font-weight="600">os-done-or-not</text>
+<rect x="465" y="446.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
+<text x="496" y="465.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
+<rect x="615" y="446.5" width="62" height="28" rx="14" fill="#C96F50" fill-opacity="0.14"/>
+<text x="646" y="465.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">7/9</text>
 <rect x="765" y="446.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="796" y="465.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
-<line x1="52" y1="485" x2="868" y2="485" stroke="#E2E0D8"/>
-<text x="52" y="514.5" fill="#1F1E1D" font-size="14" font-weight="600">os-step-by-step</text>
+<line x1="52" y1="485.0" x2="868" y2="485.0" stroke="#E2E0D8"/>
+<text x="52" y="514.5" fill="#1F1E1D" font-size="14" font-weight="600">os-say-simple</text>
 <rect x="465" y="495.5" width="62" height="28" rx="14" fill="#C96F50" fill-opacity="0.14"/>
-<text x="496" y="514.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">3/9</text>
+<text x="496" y="514.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">6/9</text>
 <rect x="615" y="495.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="646" y="514.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 <rect x="765" y="495.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
 <text x="796" y="514.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
+<line x1="52" y1="534.0" x2="868" y2="534.0" stroke="#E2E0D8"/>
+<text x="52" y="563.5" fill="#1F1E1D" font-size="14" font-weight="600">os-step-by-step</text>
+<rect x="465" y="544.5" width="62" height="28" rx="14" fill="#C96F50" fill-opacity="0.14"/>
+<text x="496" y="563.1" fill="#C96F50" font-size="13" font-weight="700" text-anchor="middle">4/9</text>
+<rect x="615" y="544.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
+<text x="646" y="563.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
+<rect x="765" y="544.5" width="62" height="28" rx="14" fill="#6A9274" fill-opacity="0.14"/>
+<text x="796" y="563.1" fill="#6A9274" font-size="13" font-weight="700" text-anchor="middle">9/9</text>
 </svg>

--- a/docs/claude-md.md
+++ b/docs/claude-md.md
@@ -22,6 +22,7 @@ Invoke the skill. Do not improvise the answer in its place.
 |---|---|
 | I ask what is next, what is left, or what is blocked | `os-whats-next` |
 | **Any technical question you put to me, or any options you offer** | `os-ask-simple` |
+| Something hard to undo is about to be agreed, or I ask what could go wrong | `os-what-could-go-wrong` |
 | **Any message where you ask me to do something** - run a command, paste a value, approve, choose, test on a device | `os-step-by-step` |
 | I ask about other sessions, or to accept work one of them finished | `os-check-work` |
 | Work is finished, or I ask how it went | `os-done-or-not` |

--- a/docs/other-agents.md
+++ b/docs/other-agents.md
@@ -20,6 +20,14 @@ mkdir -p ~/.agents/skills && cp -R open-steps/skills/os-* ~/.agents/skills/
 
 Copies, so run it again after a `git pull` to update.
 
+One skill carries over worse than the rest. `os-what-could-go-wrong` inlines
+its analysis prompt with a `!` command and hands the attack to a fresh
+subagent, and both are Claude Code behaviours. On these tools the `!` line
+arrives as literal text, and the skill then says to read
+`references/premortem-prompt.md` directly; whether the tool can dispatch a
+fresh agent varies. None of this is verified here - expect this one skill to
+run shallower than the other six.
+
 Linking instead works and updates itself, but it renames the skills. Codex
 resolves a symlink back to the clone and takes the namespace from the folder
 it lands in, so `ln -sfn "$PWD"/open-steps/skills/os-* ~/.agents/skills/`

--- a/docs/routing-block.md
+++ b/docs/routing-block.md
@@ -6,6 +6,7 @@ Invoke the skill. Do not improvise the answer in its place.
 |---|---|
 | I ask what is next, what is left, or what is blocked | `os-whats-next` |
 | **Any technical question you put to me, or any options you offer** | `os-ask-simple` |
+| Something hard to undo is about to be agreed, or I ask what could go wrong | `os-what-could-go-wrong` |
 | **Any message where you ask me to do something** - run a command, paste a value, approve, choose, test on a device | `os-step-by-step` |
 | I ask about other sessions, or to accept work one of them finished | `os-check-work` |
 | Work is finished, or I ask how it went | `os-done-or-not` |

--- a/evals/README.md
+++ b/evals/README.md
@@ -22,7 +22,7 @@ scripts in between.
   left. Every transcript says which model wrote it, so renaming a file cannot
   move a column.
 - **The transcripts stay out of the repository.** One measurement is one run of
-  the agent, so a full pass over every phrase on three models is 207 runs and
+  the agent, so a full pass over every phrase on three models is 234 runs and
   12 MB of logs. They go to `~/.claude/open-steps/evals/<day>/`, next to where
   the pack keeps its reports: one folder per day, every model inside it. To see
   what the agent actually answered, open that one file.

--- a/evals/cases.md
+++ b/evals/cases.md
@@ -32,6 +32,9 @@ that exact skill switched on by itself, with nobody naming it.
 | os-ask-simple | The plan suggests adding a message queue for emails. Is this worth doing, or would something simpler do? |
 | os-ask-simple | Should we add a queue here or is that overkill? What would you pick? |
 | os-ask-simple | You need a decision from me about the database. Ask me simply. |
+| os-what-could-go-wrong | We are about to sign a three-year office lease with no break clause. What could go wrong? |
+| os-what-could-go-wrong | Before we migrate the database this Saturday, poke holes in the plan: one four-hour window, 50 million rows, and rollback is repointing back. |
+| os-what-could-go-wrong | We have decided to raise prices 20% for existing customers next month. Do a premortem on it, what are we missing? |
 
 ## Should not fire
 

--- a/evals/results.md
+++ b/evals/results.md
@@ -3,19 +3,20 @@
 Written by `score.py` from the raw streams, so no number here is typed
 by hand. The phrases are in [`cases.md`](cases.md).
 
-Day `2026-08-24`, models Haiku 4.5, Sonnet 5, Opus 5. Every phrase asked 3 times per model.
+Day `2026-08-29`, models Haiku 4.5, Sonnet 5, Opus 5. Every phrase asked 3 times per model.
 
 ## Did the right skill switch on by itself
 
 | Skill | Haiku 4.5 | Sonnet 5 | Opus 5 |
 |---|---|---|---|
-| `os-done-or-not` | 9/9 | 9/9 | 9/9 |
+| `os-done-or-not` | 9/9 | 7/9 | 9/9 |
 | `os-whats-next` | 9/9 | 9/9 | 9/9 |
 | `os-check-work` | 9/9 | 9/9 | 9/9 |
-| `os-say-simple` | 5/9 | 9/9 | 9/9 |
-| `os-step-by-step` | 3/9 | 9/9 | 9/9 |
-| `os-ask-simple` | 8/9 | 7/9 | 9/9 |
-| **All phrases** | **43/54 (79%)** | **52/54 (96%)** | **54/54 (100%)** |
+| `os-say-simple` | 6/9 | 9/9 | 9/9 |
+| `os-step-by-step` | 4/9 | 9/9 | 9/9 |
+| `os-ask-simple` | 9/9 | 8/9 | 9/9 |
+| `os-what-could-go-wrong` | 9/9 | 9/9 | 9/9 |
+| **All phrases** | **55/63 (87%)** | **60/63 (95%)** | **63/63 (100%)** |
 | Fired on an off-topic question | 1/9 | 0/9 | 0/9 |
 
 ## Phrase by phrase
@@ -23,7 +24,7 @@ Day `2026-08-24`, models Haiku 4.5, Sonnet 5, Opus 5. Every phrase asked 3 times
 | Skill | Phrase | Haiku 4.5 | Sonnet 5 | Opus 5 |
 |---|---|---|---|---|
 | `os-done-or-not` | The work is finished, are we done? Give me the report. | 3/3 | 3/3 | 3/3 |
-| `os-done-or-not` | That's it for today. What happened? | 3/3 | 3/3 | 3/3 |
+| `os-done-or-not` | That's it for today. What happened? | 3/3 | 1/3 | 3/3 |
 | `os-done-or-not` | Report, please. How did the session go? | 3/3 | 3/3 | 3/3 |
 | `os-whats-next` | What's next? What should we pick up now? | 3/3 | 3/3 | 3/3 |
 | `os-whats-next` | What is left to do, anything I can pick up? | 3/3 | 3/3 | 3/3 |
@@ -32,14 +33,17 @@ Day `2026-08-24`, models Haiku 4.5, Sonnet 5, Opus 5. Every phrase asked 3 times
 | `os-check-work` | The other session says it finished. Check its work. | 3/3 | 3/3 | 3/3 |
 | `os-check-work` | How are the other sessions doing? | 3/3 | 3/3 | 3/3 |
 | `os-say-simple` | My agent in another session sent me this: "The retry storm was mitigated by idempotency-ke ... | 3/3 | 3/3 | 3/3 |
-| `os-say-simple` | Here is the update I got: "Rebased onto main after the squash-merge invalidated ancestry; ... | 2/3 | 3/3 | 3/3 |
+| `os-say-simple` | Here is the update I got: "Rebased onto main after the squash-merge invalidated ancestry; ... | 3/3 | 3/3 | 3/3 |
 | `os-say-simple` | The reviewer wrote: "LGTM modulo the N+1 in the serializer; also the dedup belongs at the ... | 0/3 | 3/3 | 3/3 |
 | `os-step-by-step` | I have to put a secret on the server. Tell me exactly what to do. | 1/3 | 3/3 | 3/3 |
 | `os-step-by-step` | The registrar emailed that I must approve the domain change manually. Explain step by step ... | 2/3 | 3/3 | 3/3 |
-| `os-step-by-step` | The setup doc says the database password must be set by me, not by the agent. I don't unde ... | 0/3 | 3/3 | 3/3 |
+| `os-step-by-step` | The setup doc says the database password must be set by me, not by the agent. I don't unde ... | 1/3 | 3/3 | 3/3 |
 | `os-ask-simple` | The plan suggests adding a message queue for emails. Is this worth doing, or would somethi ... | 3/3 | 3/3 | 3/3 |
-| `os-ask-simple` | Should we add a queue here or is that overkill? What would you pick? | 2/3 | 1/3 | 3/3 |
+| `os-ask-simple` | Should we add a queue here or is that overkill? What would you pick? | 3/3 | 2/3 | 3/3 |
 | `os-ask-simple` | You need a decision from me about the database. Ask me simply. | 3/3 | 3/3 | 3/3 |
+| `os-what-could-go-wrong` | We are about to sign a three-year office lease with no break clause. What could go wrong? | 3/3 | 3/3 | 3/3 |
+| `os-what-could-go-wrong` | Before we migrate the database this Saturday, poke holes in the plan: one four-hour window ... | 3/3 | 3/3 | 3/3 |
+| `os-what-could-go-wrong` | We have decided to raise prices 20% for existing customers next month. Do a premortem on i ... | 3/3 | 3/3 | 3/3 |
 
 ## Report quality on the same messy input
 
@@ -48,9 +52,9 @@ Small numbers, read them as a smoke test.
 
 | Model | pack | verdict block | warning row | lines | hashes | jargon |
 |---|---|---|---|---|---|---|
-| Haiku 4.5 | with | 0% | 0% | 9.7 | 0.0 | 0.0 |
-| Haiku 4.5 | without | 0% | 33% | 13.0 | 0.0 | 1.3 |
-| Sonnet 5 | with | 0% | 0% | 10.0 | 1.3 | 1.3 |
-| Sonnet 5 | without | 0% | 0% | 9.7 | 0.0 | 1.0 |
-| Opus 5 | with | 0% | 100% | 10.7 | 1.3 | 0.3 |
-| Opus 5 | without | 0% | 0% | 9.0 | 0.0 | 0.0 |
+| Haiku 4.5 | with | 0% | 0% | 12.3 | 0.0 | 1.0 |
+| Haiku 4.5 | without | 0% | 33% | 11.3 | 0.0 | 1.3 |
+| Sonnet 5 | with | 0% | 0% | 9.3 | 0.7 | 2.0 |
+| Sonnet 5 | without | 0% | 33% | 9.7 | 0.7 | 0.7 |
+| Opus 5 | with | 0% | 100% | 12.7 | 2.0 | 0.3 |
+| Opus 5 | without | 0% | 33% | 8.7 | 0.0 | 0.0 |

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -26,7 +26,7 @@ PAR="${EVAL_PARALLEL:-5}"
 if command -v timeout >/dev/null 2>&1; then LIMIT="timeout 240"
 elif command -v gtimeout >/dev/null 2>&1; then LIMIT="gtimeout 240"
 else LIMIT=""; fi
-# A full sweep is 207 separate agent runs, so it is 207 transcripts. They live
+# A full sweep is 234 separate agent runs, so it is 234 transcripts. They live
 # outside the repository, next to where the pack keeps its reports: one folder
 # per day, every model in it, each file carrying its model in the name. Running
 # one model again replaces that model's files and leaves the rest of the day

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -27,6 +27,7 @@ These moments require a skill. Invoke it rather than improvising the answer.
 
 - I ask what is next, what is left, or what is blocked -> os-whats-next
 - Any technical question you put to me, or any options you offer -> os-ask-simple
+- Something hard to undo is about to be agreed, or I ask what could go wrong -> os-what-could-go-wrong
 - Any message where you ask me to do something (run a command, paste a value,
   approve, choose, test on a device) -> os-step-by-step
 - I ask about other sessions, or to accept work one of them finished -> os-check-work

--- a/skills/os-what-could-go-wrong/SKILL.md
+++ b/skills/os-what-could-go-wrong/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: os-what-could-go-wrong
+description: >-
+  ALWAYS invoke this skill before anything hard to undo gets agreed to - a
+  contract, a purchase, a migration, a launch, a price change, a
+  reorganisation - and whenever the user asks "what could go wrong", "what are
+  we missing", "poke holes in this", or for a premortem or a red team, in any
+  language. Assumes the decision already failed and works backwards to find
+  out why, in a fresh agent that had no hand in making it. Sweeps nine areas
+  and shows what each produced, including the empty ones. Ends on one verdict:
+  go ahead, go but fix these first, try it small first, think again, do not do
+  this.
+allowed-tools:
+  - "Read(~/.claude/open-steps/**)"
+---
+
+# os-what-could-go-wrong
+
+Assume it already failed, then work backwards to find out why - while there is
+still time to change it. The attack runs in a fresh agent that had no part in
+the decision, because an agent that helped shape one reviews it far too
+gently: it defends its own reasoning, and it misses the thing that kills the
+plan out of politeness. This skill writes the brief, hands it over, and passes
+the answer back without softening it.
+
+`os-ask-simple` screens a choice before the user picks one. This one runs
+after the choice is made and before it can no longer be taken back.
+
+## Language
+
+Write in the language the user speaks in this session, detected from the
+conversation. Names, figures and identifiers stay as they are. The agent you
+dispatch cannot see this conversation and does not inherit the writing style,
+so the language has to travel with the handover - see step 2.
+
+## Step 1 - write down what is actually being decided
+
+Find the decision first. Given as text or a document, that is it. Asked at the
+end of a discussion, it is the decision the discussion arrived at, and say
+which one you took it to be. If neither, ask which decision to attack.
+
+Then fill every line. This is the only thing the fresh agent will ever see.
+
+```
+DECISION BRIEF
+What will be done: three to seven sentences
+What it is for: the problem it solves, and what success looks like, measured
+  wherever it can be
+The main moves: the money, the people, the systems, the dates
+What is fixed: the constraints, plus the surrounding facts that matter
+Who it lands on: who and what is affected if this goes wrong
+What cannot be undone: which parts are one-way
+When we would know: the date success or failure actually gets judged
+What we know: facts from documents, data, the repository, past incidents,
+  each with where it came from
+What we are assuming: every gap nobody could close, written as an assumption
+```
+
+Close the gaps in this order, and stop as soon as a gap is closed.
+
+1. **Look it up yourself.** Documents, data, the repository, the last report
+   in `~/.claude/open-steps/reports/`, what went wrong last time.
+2. **Ask, but earn the ask.** Only a gap where guessing wrong would change the
+   verdict is worth the user's attention, and the pack's own rule holds here:
+   one question at a time, through `os-ask-simple`. Three is plenty. Nobody
+   there to answer, or the answer would not move the verdict, means skip
+   straight to 3.
+3. **Write the guess down as a guess.** Put the assumed value in its line,
+   mark it `(assumed)`, and repeat it under "What we are assuming".
+
+The brief states facts and open questions. It never makes the case for the
+decision: a brief that argues gets a report that agrees.
+
+## Step 2 - hand it to an agent that had no part in it
+
+Pick the depth, say which one in a single line, and carry on. The user can
+change it at any point.
+
+| Depth | When |
+|---|---|
+| **Full** | Hard to undo, or being wrong costs money, trust or data beyond one team |
+| **Quick** | Reversible, and cheap to be wrong about, whoever it touches |
+
+When in doubt, Full. The cost of a full look is a few minutes; the cost of a
+quick look at a one-way door is the door.
+
+Dispatch one general-purpose agent. Its prompt is these four things in order,
+nothing else:
+
+1. the whole text of
+   [`references/premortem-prompt.md`](references/premortem-prompt.md)
+2. `MODE: Full` or `MODE: Quick`
+3. `LANGUAGE: <the language from above>`
+4. the brief
+
+Never summarise that file or paste part of it. Its rules are what stop the
+answer turning into a list of worries, and the writing rules inside it are the
+only ones that reach the agent at all.
+
+For a large Full decision, two or three agents in parallel is worth it: keep
+every distinct risk that survives, and where two describe the same one, keep
+the version with better evidence behind it.
+
+## Step 3 - give it to the user straight
+
+Pass the report through as it came. No reassurance the analysis did not earn,
+no cushion sentence in front of the verdict, no quietly dropped card because
+the user seemed committed. Bad news that arrives late is worth nothing.
+
+Then offer to turn the "Fix before you commit" list into real things: edits to
+the plan, tickets, an owner and a date per item, a reminder for each early
+warning. That offer is the point of the whole exercise - a premortem nobody
+acts on was entertainment.
+
+"Go ahead" is delivered just as plainly. It means the plan was attacked and
+held.
+
+## Hard rules
+
+1. **The agent that helped decide never attacks the decision.** Dispatch a
+   fresh one every time, even when you already hold the whole thing in
+   context. Skipping this does not save a step, it changes the answer.
+2. **No quota of risks.** Publish what has a real chain behind it and nothing
+   else. Two well-evidenced risks beat six padded ones, and "only two
+   survived" is a finding worth saying out loud.
+3. **The verdict is decided last and printed first.** Never make the reader
+   assemble it from the risks.
+4. **Every area of the sweep is accounted for**, including the ones that
+   produced nothing. An area nobody mentions and an area nobody checked look
+   the same to the reader.
+5. **A skipped section keeps its one line saying why.**
+6. **A lease and a database migration get the same treatment.** This is not a
+   technical review; the nine areas apply to both, and the money and people
+   ones are where technical decisions usually actually fail.
+7. **"The plan is sound" is a legitimate answer** once the attack has run. It
+   is never a substitute for running one.
+
+## Known gotchas
+
+- **No date to be judged by means no premortem.** "It failed" is meaningless
+  without "by when". Pick a date that fits the decision, and say you picked it.
+- **The brief is where this is won or lost.** The fresh agent sees nothing
+  else. The usual failure is a brief missing the one constraint that made the
+  decision sensible, which produces a confident report attacking a plan nobody
+  proposed.
+- **Fewer than three risks reads as a lazy analysis and is often the right
+  answer.** The record of what was checked is what tells those apart.
+- **Something reversible and cheap does not need this.** Quick look, or say it
+  does not need one. Running a full attack on a two-day experiment teaches the
+  user to ignore the next one.
+- **"Try it small first" is not a soft no.** It means the unknowns are
+  testable and worth testing before the money moves.
+- **The user may go ahead against all of it.** That is their decision and they
+  now have the early warnings. Note it once, set the tripwires up if they want
+  them, and do not re-argue the report.

--- a/skills/os-what-could-go-wrong/SKILL.md
+++ b/skills/os-what-could-go-wrong/SKILL.md
@@ -12,6 +12,7 @@ description: >-
   this.
 allowed-tools:
   - "Read(~/.claude/open-steps/**)"
+  - "Bash(cat ${CLAUDE_SKILL_DIR}/references/premortem-prompt.md)"
 ---
 
 # os-what-could-go-wrong
@@ -87,15 +88,15 @@ quick look at a one-way door is the door.
 Dispatch one general-purpose agent. Its prompt is these four things in order,
 nothing else:
 
-1. the whole text of
-   [`references/premortem-prompt.md`](references/premortem-prompt.md)
+1. the whole analysis prompt - already inlined at the bottom of this skill,
+   under "The analysis prompt, verbatim"
 2. `MODE: Full` or `MODE: Quick`
 3. `LANGUAGE: <the language from above>`
 4. the brief
 
-Never summarise that file or paste part of it. Its rules are what stop the
-answer turning into a list of worries, and the writing rules inside it are the
-only ones that reach the agent at all.
+Copy the inlined prompt exactly. Never summarise it or paste part of it. Its
+rules are what stop the answer turning into a list of worries, and the writing
+rules inside it are the only ones that reach the agent at all.
 
 One agent, not several. Two reports have two verdicts and two candidates for
 the single belief nobody is questioning, and merging them is exactly the
@@ -153,3 +154,14 @@ held.
 - **The user may go ahead against all of it.** That is their decision and they
   now have the early warnings. Note it once, set the tripwires up if they want
   them, and do not re-argue the report.
+
+## The analysis prompt, verbatim
+
+The block below is the whole of
+[`references/premortem-prompt.md`](references/premortem-prompt.md), inlined
+when this skill loads, so no file has to be read at dispatch time. If the
+block shows a literal `cat` command instead of the prompt, this harness does
+not run inline commands: open that file next to this one and use its full
+text.
+
+!`cat ${CLAUDE_SKILL_DIR}/references/premortem-prompt.md`

--- a/skills/os-what-could-go-wrong/SKILL.md
+++ b/skills/os-what-could-go-wrong/SKILL.md
@@ -63,7 +63,7 @@ Close the gaps in this order, and stop as soon as a gap is closed.
 2. **Ask, but earn the ask.** Only a gap where guessing wrong would change the
    verdict is worth the user's attention, and the pack's own rule holds here:
    one question at a time, through `os-ask-simple`. Three is plenty. Nobody
-   there to answer, or the answer would not move the verdict, means skip
+   there to answer, or an answer that would not move the verdict -> skip
    straight to 3.
 3. **Write the guess down as a guess.** Put the assumed value in its line,
    mark it `(assumed)`, and repeat it under "What we are assuming".
@@ -97,9 +97,9 @@ Never summarise that file or paste part of it. Its rules are what stop the
 answer turning into a list of worries, and the writing rules inside it are the
 only ones that reach the agent at all.
 
-For a large Full decision, two or three agents in parallel is worth it: keep
-every distinct risk that survives, and where two describe the same one, keep
-the version with better evidence behind it.
+One agent, not several. Two reports have two verdicts and two candidates for
+the single belief nobody is questioning, and merging them is exactly the
+editing that step 3 forbids.
 
 ## Step 3 - give it to the user straight
 

--- a/skills/os-what-could-go-wrong/references/01-office-lease.md
+++ b/skills/os-what-could-go-wrong/references/01-office-lease.md
@@ -1,12 +1,11 @@
 # Example 1 - a three-year office lease
 
-Source: a synthetic decision written for this example. No real company, nothing
-confidential, no third-party material. Both halves are real agent output on the
-same facts. The BEFORE is what a general-purpose agent answered when the
-decision was put to it directly, with no skill in play. The AFTER is what this
-skill produced from the same facts. The BEFORE is abridged wherever you see an
-ellipsis; the AFTER is part one only, which is the screen the reader is meant
-to be able to stop at.
+Source: an invented decision, written for this example. No real company,
+nothing confidential, no third-party material. Both halves are real agent
+output on the same facts: the BEFORE is what a general-purpose agent answered
+when the decision was put to it with no skill in play, the AFTER is what this
+skill produced. Both are abridged wherever you see an ellipsis, and punctuation
+is normalised to this repository's style; no wording is changed.
 
 Kept because the BEFORE is good. That is the point of it. It is not a lazy
 answer that a better prompt would fix - it is a careful, well-informed answer
@@ -27,9 +26,6 @@ that the person still cannot act on or audit.
 > $310k burn excludes the office, and that $28k is net of service charge...)*
 >
 > ## 1. The cost model is missing 30-40%
-> | Item | 3-year cost |
-> | Base rent (your figure) | $1.04M |
-> | Service charge, rates, insurance, utilities, cleaning | $250-450k |
 > ... **Realistic total $1.8-2.2M**... **Runway impact.** $2.4M / $310k = 7.7
 > months today... you're at **~5.8 months**...
 >
@@ -69,77 +65,193 @@ that the person still cannot act on or audit.
 | No verdict anywhere | Six sections of analysis, then the answer as the last heading. The reader has to reach the bottom to learn what to do |
 | You cannot tell what was skipped | Six areas, chosen by the writer. Competitor response is never mentioned - considered and empty, or never looked at? Nothing says |
 | Nothing is scored | Every risk is prose. Which is likeliest, which is worst, and which you would not see coming are three different questions, and the reader is left to separate them |
-| The load-bearing belief is a footnote | "Two assumptions worth confirming" in italics under the opening. The one belief the whole $2M rests on is never isolated |
-| Warnings nobody can act on | "Don't proceed if more than two senior mentors signal departure" - measured how, checked when, and by whom? |
+| The load-bearing belief is a footnote | "Two assumptions worth confirming" in italics under the opening. The one belief the whole decision rests on is never isolated |
+| Warnings nobody can act on | "Don't proceed if more than two senior mentors signal departure" - measured how, checked when, by whom? |
 | The ordinary failures are never swept | The class of decision is never named, so the ways this kind of deal usually dies are never worked through as a list |
 
-## AFTER - os-what-could-go-wrong, part one (23 lines)
+All six are cured somewhere below. The first two are cured on the screen; the
+other four are cured underneath it, which is why this example shows all four
+layers rather than stopping at part one.
 
-> # What could go wrong - signing a 3-year, $1.04M city-centre lease with a personal guarantee
+## AFTER - part one, the screen (24 lines)
+
+> # What could go wrong - signing a 3-year, $1.04M city-centre office lease and mandating 3 days a week
 >
 > | | |
 > |---|---|
 > | **Verdict** | **Think again** |
-> | **Why** | The company has 7.7 months of cash and is about to sign a 36-month personal guarantee with no break clause. The commitment outlives the funded life of the business by more than two years. |
-> | **Worst case** | The company runs out of money around month 8. The landlord calls the guarantee. One director is personally liable for roughly **$650,000-$815,000**, plus make-good costs and legal fees. Before that, ~$348,000 of cash leaves the building before anyone sets foot in it, and around 7 people - weighted toward the seniors the juniors were supposed to learn from - have already gone. |
+> | **Why** | At $310k/month burn against $2.4M cash, the company runs out of money around month 6 after signing - roughly ten months before month 12, the date it planned to grade this decision by. |
+> | **Worst case** | $348,000 of cash gone before anyone sits down, ~$1.04M of non-cancellable rent, one director personally liable for the unpaid remainder, 7-11 of 40 staff gone, and no measurement that can tell you whether any of it worked. |
 >
 > **The biggest risks**
 >
-> 1. Cash $2,400,000 / burn $310,000 = **7.7 months of runway** against a
->    36-month obligation. Nothing in the brief says where money for months
->    8-36 comes from. (risk 1)
-> 2. The two ways out both fail. Sublease comps are already **15-20% below
->    asking**, and a guarantee normally survives a sublet. (risk 2)
-> 3. The three-week deadline forecloses roughly **$300,000-$412,000** of
->    negotiable value and, more importantly, the guarantee cap and break
->    clause that would make risks 1 and 2 survivable. (risk 3)
+> 1. The runway ends before the answer arrives. $348,000 out up front, burn
+>    rises ~11%, cash hits zero ~2.4 months after move-in; the success metrics
+>    are dated month 6 and month 12. (risk 1)
+> 2. Attrition lands on the people you can least replace, and it starts at the
+>    announcement - two months before move-in, when every dollar is already
+>    committed. 11 of 31 survey respondents already flagged themselves. (risk 2)
+> 3. The personal guarantee converts a company failure into one director's
+>    personal debt, and after signature that director's own interests argue
+>    against an honest month-6 review. (risk 3)
 >
 > **The thing nobody is questioning**
 >
-> That there will be more money. The brief prices the rent to the dollar and
-> never states the runway, the revenue, or the raise - yet every number in it
-> silently assumes funding that is not mentioned, not sized, and not made a
-> condition of signing.
+> That this is a decision about how the company works, with a cost attached -
+> rather than a financing decision with a culture story attached.
 >
 > **Fix before you commit**
 >
-> - Write down the funding plan for months 8-36 and make signing conditional
->   on it. If it isn't closed, do not sign. (risk 1)
-> - Cap the personal guarantee at 6-12 months' rent, or make it burn off after
->   18-24 months of on-time payment. (risk 1)
-> - Get a break clause at month 18 or 24. Without one there is no month-12
->   decision, because there is no month-12 action. (risks 2, 7)
-> - Decide the 12 remote contracts **before** the announcement, in writing.
->   If they are exempt, the 80% target is arithmetically impossible: 28 of 40
->   is 70%. (risk 5)
-> - Read every junior exit interview from the last 24 months and count the
->   stated reasons. Two days of work, and it tests the causal claim the whole
->   $1.2M rests on. (risk 4)
+> - Do not sign inside the three-week window. Ask for it to be extended; if the
+>   answer is no, walk and see whether the phone rings... (risk 6)
+> - Trade the personal guarantee against the six-month deposit. Landlords
+>   normally take one or the other. Worth $84,000 of cash or one director's
+>   house. (risks 3, 6)
+> - Decide the 12 remote contracts in writing, before any expectation is
+>   announced. Then check the arithmetic: with 12 exempt, 80% is unreachable
+>   until headcount passes 60. (risk 5)
+> - Start measuring cycle time today, from the existing tracker. One day of
+>   work. Without a baseline, "a measurable drop in time-to-ship" cannot be
+>   passed or failed at month 12. (risk 4)
+> - ...
+>
+> **The decision, rewritten**
+>
+> Do not sign this lease in this window. Spend the next quarter on the free
+> version of the same thesis: baseline cycle time from the tracker, put a named
+> mentor and daily pairing on every junior, and take 20-30 flexible desks or a
+> 12-month serviced office near where staff already cluster - well under
+> $150,000 a year, cancellable, no guarantee...
 
-(Underneath part one, the same report carries the nine-area record of what was
-checked, seven risk cards, and the cross-cutting findings. The reader who stops
-at the screen above still has the verdict, the three worst risks, and the list
-of things to do before signing.)
+## AFTER - the outside view, which the BEFORE has no equivalent of
+
+> ### What usually kills decisions like this
+>
+> Two classes stacked: **a long, non-cancellable fixed commitment signed under
+> a deadline**, and **a return-to-office mandate imposed on staff who were
+> hired remotely**.
+>
+> Committed leases usually fail in six ordinary ways. (1) *The commitment
+> outlives the plan*... (2) *Runway math* - the lease survives the tenant...
+> (3) *Concessions left on the table because of a clock*... (4) *Fit-out
+> overruns and schedule slips*... (5) *Dilapidations and exit costs*... (6)
+> *The exit that isn't* - sublease rights look like an escape hatch and recover
+> a fraction, slowly, in the same weak market that made you want out.
+>
+> Mandates usually fail in four. (7) *Attrition concentrates in the most
+> marketable staff*... (8) *Compliance gets measured as attendance rather than
+> as the outcome the office was meant to buy*... (9) *The mandate is announced,
+> softened under pressure*... (10) *A symptom is attributed to the wrong
+> cause*...
+>
+> **Live here: all ten.** Growth to 65 is unfunded (1). Runway is 7.7 months
+> against a 36-month term (2). Zero concessions in a market listing 15-20%
+> below asking (3)...
+>
+> **Not live:** the space being too small - 6,000 sq ft is about right for 65
+> hybrid and generous for 40. Landlord insolvency mid-term is possible but
+> unevidenced... A regulatory shock that empties offices again is a tail risk
+> nobody can forecast, but note there is no break clause if one comes.
+
+The "not live" paragraph is the part that makes this checkable. A reader can
+disagree with it. Nothing in the BEFORE can be disagreed with in that way,
+because nothing in it says what was considered and dismissed.
+
+## AFTER - the record of the sweep
+
+> ### What was checked
+>
+> - **Will people use it** - Two risks. The 80% target is arithmetically
+>   unreachable as written (risk 5), and the thing it is meant to buy was never
+>   diagnosed (risk 4).
+> - **Money** - Three risks. The runway (risk 1), the deal terms against the
+>   market (risk 6), and the sublet that doesn't recover what people think
+>   (risk 7).
+> - **Building it** - One risk. $180,000 across 6,000 sq ft is $30/sq ft, and
+>   the four-month window has no facilities hire in it yet (risk 8).
+> - **Running it day to day** - One risk... (risk 10).
+> - **The people involved** - Two risks... (risks 2, 3).
+> - **Things you depend on** - Folded into risks 6, 7 and 8: the landlord is
+>   the counterparty on the deadline, on sublet consent, and on holding
+>   $168,000 that may not be in escrow...
+> - **Legal and rules** - Folded into risks 3 and 5...
+> - **People misusing it** - One risk. Presence theatre keeps the metric green
+>   and the money flowing past the point the thesis failed (risk 9)...
+> - **What others do about it** - Real, but as a mechanism inside risk 2 rather
+>   than its own card: remote-first competitors treat a dated mandate as a
+>   recruiting signal...
+
+Nine lines, nine areas, including the ones that produced no card of their own
+and why. This is the part that answers "what did you not look at", and it is
+the reason the sweep can be trusted without the reader repeating it.
+
+## AFTER - one risk card, to show the shape
+
+> ### 5. The 80% target is impossible as written, and the only way to make it possible breaks 12 contracts [Will people use it / Legal] - Fix before you commit
+>
+> - **How it happens:** 12 of 40 staff are on explicitly remote contracts... If
+>   they are exempt - which the brief assumes but has not decided - the maximum
+>   attendance is **28 of 40 = 70%**, at perfect compliance from everyone who
+>   can comply. The 80% target fails on announcement day, by definition... If
+>   instead they are *not* exempt, you are unilaterally changing an expressly
+>   agreed contractual term for 30% of the company... There is no third option,
+>   and the brief has chosen neither.
+> - **What we are assuming:** "That a three-day expectation is enforceable
+>   against staff hired remotely" - the author's own assumption...
+> - **What this is based on:** "All 40 staff, of whom 12 were hired on
+>   explicitly remote contracts..." "80% of staff in the office three or more
+>   days a week by month six."
+> - **How likely:** **High**, and for the arithmetic, certain. My estimate of
+>   the realistic month-6 figure... **20-23 people at 3+ days, about 50-58%**...
+> - **How bad:** **Serious.** The headline success criterion is unachievable,
+>   so the month-6 review has no honest way to pass...
+> - **Would you see it coming:** **Easily.** It is division. Nobody has done it.
+> - **How it shows up:** Announcement week: the first question in the all-hands
+>   is "does this apply to the remote team?", and there is no answer. Weeks
+>   2-8: exemption requests from non-exempt staff... Month 6: 50-58% against a
+>   target of 80%, and a debate about the denominator instead of the outcome.
+> - **Early warning:** *What to watch* - the exemption policy: written, dated,
+>   with named criteria and a named decider · *When to worry* - no written
+>   policy exists on the day of the announcement, or exemption requests exceed
+>   4 in the first month · *When to check* - before signature, and weekly for
+>   the first eight weeks after announcement · *What to do then* - publish the
+>   criteria and the appeal route the same day...
+> - **What to do about it:** Decide the exemption in writing before you
+>   announce anything, and restate the goal as a number that can be reached...
+>   **What gets worse:** a written exemption for 12 people makes the two-tier
+>   company explicit and visible... That resentment is real - and it exists
+>   either way; writing it down just makes it manageable.
+
+Three separate scores, and the one that does the most work is the cheapest:
+"Would you see it coming: Easily. It is division. Nobody has done it." The
+early warning names a signal, a threshold, a checkpoint and an action, so it
+can be handed to somebody. Compare the BEFORE's "if more than two senior
+mentors signal departure", which cannot.
 
 ## What this example changed in the format
 
-1. **The outside-view section exists because of this run.** The report attacked
-   the reference class properly - standard commercial-lease practice on
-   guarantees, the documented pattern of return-to-office mandates losing the
-   most marketable staff - but all of it was buried inside individual cards.
-   Asked directly, the agent confirmed: "No standalone section named the
-   reference class." A reader could not check whether the ordinary ways this
-   kind of deal dies had been swept. It is now a section of its own, and the
-   cards cite it.
-2. **Every line of "Fix before you commit" carries its risk number.** Without
-   them the list reads as loose advice. With them, each item can be traced
-   back to the mechanism that earned it, and an item with no card behind it is
-   visible as padding.
-3. **Part one has to survive being read alone.** The verdict, the worst case,
-   the three risks, the one hidden belief and the actions all fit on a screen.
-   Everything below it is working, not answer. That split is what lets someone
-   who does not read contracts use the same report as the person who does.
-4. **The empty areas are worth as much as the full ones.** In this run
-   "people misusing it" and "what others do about it" produced no risk that
-   kills the decision on its own. Saying so, and saying what was found instead,
-   is the difference between a sweep and a list of whatever came to mind.
+1. **The outside-view section exists because of this pair.** The first run
+   attacked the reference class properly, but only inside individual cards, so
+   nothing named it and a reader could not check whether the ordinary ways such
+   deals die had been swept. Asked directly, the agent confirmed there was no
+   standalone section. "What usually kills decisions like this" is now a
+   section of its own, and cards cite it. On the re-run above it produced ten
+   named killers and a "not live" list.
+2. **Part one stopped showing three numbered risk slots.** A template with
+   exactly three slots reimposes the quota that three separate rules exist to
+   remove. It now says at most three, one per surviving risk, and says what to
+   write when nothing survived.
+3. **Every line of "Fix before you commit" carries its risk number.** Without
+   them the list reads as loose advice. With them each item traces back to the
+   mechanism that earned it, and an item with no card behind it is visible as
+   padding.
+4. **The empty areas are worth as much as the full ones.** Here "things you
+   depend on" and "what others do about it" produced no card of their own. Both
+   still get a line saying where the mechanism went instead. That is the
+   difference between a sweep and a list of whatever came to mind.
+5. **Still unfixed, and visible above: the report leaks specialist words.**
+   "Dilapidations", "escrow", "covenant", "in escrow or the landlord's money" -
+   all appear without saying what the person would actually see happen, which
+   is the rule at the top of the analysis prompt. Part one is clean; the detail
+   is not. The rule is right and the output does not fully obey it yet, so a
+   later example should be the one that closes this, not a promise here.

--- a/skills/os-what-could-go-wrong/references/01-office-lease.md
+++ b/skills/os-what-could-go-wrong/references/01-office-lease.md
@@ -1,0 +1,145 @@
+# Example 1 - a three-year office lease
+
+Source: a synthetic decision written for this example. No real company, nothing
+confidential, no third-party material. Both halves are real agent output on the
+same facts. The BEFORE is what a general-purpose agent answered when the
+decision was put to it directly, with no skill in play. The AFTER is what this
+skill produced from the same facts. The BEFORE is abridged wherever you see an
+ellipsis; the AFTER is part one only, which is the screen the reader is meant
+to be able to stop at.
+
+Kept because the BEFORE is good. That is the point of it. It is not a lazy
+answer that a better prompt would fix - it is a careful, well-informed answer
+that the person still cannot act on or audit.
+
+## BEFORE - the same decision, no skill (~90 lines)
+
+> ## The short version
+>
+> You're committing three years and roughly **$1.7-2.0M all-in**, backed by a
+> **director's personal assets**, to test a hypothesis you cannot measure for
+> 12-18 months, with **7.7 months of cash in the bank**, in a market that's
+> discounting 15-20%, under a three-week deadline set by the counterparty.
+>
+> Almost every one of those factors independently argues for slowing down...
+>
+> *(Working from your numbers only. Two assumptions worth confirming: that the
+> $310k burn excludes the office, and that $28k is net of service charge...)*
+>
+> ## 1. The cost model is missing 30-40%
+> | Item | 3-year cost |
+> | Base rent (your figure) | $1.04M |
+> | Service charge, rates, insurance, utilities, cleaning | $250-450k |
+> ... **Realistic total $1.8-2.2M**... **Runway impact.** $2.4M / $310k = 7.7
+> months today... you're at **~5.8 months**...
+>
+> ## 2. The personal guarantee is the real tail risk
+> ... **It bites precisely when the company fails.**... **It creates a live
+> governance conflict.**...
+>
+> ## 3. Your own survey is telling you something you may be discounting
+> ... Expect **4-8 regretted departures in year one**...
+>
+> ## 4. The diagnosis may be wrong, and it's cheap to check
+> ... **55% retention on what denominator?** If it's 3 of 6 juniors, n=3 cannot
+> carry a $2M decision...
+>
+> ## 5. The structure is backwards on timing
+> ... **"Three weeks or it goes" is very likely manufactured.**...
+>
+> ## 6. Two execution details that quietly break the plan
+> ... **The space is too big if the mandate fails and too small if it
+> succeeds.**...
+>
+> ## What I'd actually recommend
+>
+> **Don't sign in three weeks.** Instead: 1. Buy the experiment, not the
+> conclusion... 2. Fix the mentorship problem in parallel... 3. If you do
+> lease, renegotiate as a tenant in a soft market...
+>
+> **Tripwires - agree these before you sign anything:** don't proceed if fewer
+> than ~two-thirds of the 12 remote-contract staff agree in writing to new
+> terms; if more than two senior mentors signal departure; if post-outlay
+> runway is under 9 months without committed funding...
+
+**What is wrong with it**
+
+| Defect | Where |
+|---|---|
+| No verdict anywhere | Six sections of analysis, then the answer as the last heading. The reader has to reach the bottom to learn what to do |
+| You cannot tell what was skipped | Six areas, chosen by the writer. Competitor response is never mentioned - considered and empty, or never looked at? Nothing says |
+| Nothing is scored | Every risk is prose. Which is likeliest, which is worst, and which you would not see coming are three different questions, and the reader is left to separate them |
+| The load-bearing belief is a footnote | "Two assumptions worth confirming" in italics under the opening. The one belief the whole $2M rests on is never isolated |
+| Warnings nobody can act on | "Don't proceed if more than two senior mentors signal departure" - measured how, checked when, and by whom? |
+| The ordinary failures are never swept | The class of decision is never named, so the ways this kind of deal usually dies are never worked through as a list |
+
+## AFTER - os-what-could-go-wrong, part one (23 lines)
+
+> # What could go wrong - signing a 3-year, $1.04M city-centre lease with a personal guarantee
+>
+> | | |
+> |---|---|
+> | **Verdict** | **Think again** |
+> | **Why** | The company has 7.7 months of cash and is about to sign a 36-month personal guarantee with no break clause. The commitment outlives the funded life of the business by more than two years. |
+> | **Worst case** | The company runs out of money around month 8. The landlord calls the guarantee. One director is personally liable for roughly **$650,000-$815,000**, plus make-good costs and legal fees. Before that, ~$348,000 of cash leaves the building before anyone sets foot in it, and around 7 people - weighted toward the seniors the juniors were supposed to learn from - have already gone. |
+>
+> **The biggest risks**
+>
+> 1. Cash $2,400,000 / burn $310,000 = **7.7 months of runway** against a
+>    36-month obligation. Nothing in the brief says where money for months
+>    8-36 comes from. (risk 1)
+> 2. The two ways out both fail. Sublease comps are already **15-20% below
+>    asking**, and a guarantee normally survives a sublet. (risk 2)
+> 3. The three-week deadline forecloses roughly **$300,000-$412,000** of
+>    negotiable value and, more importantly, the guarantee cap and break
+>    clause that would make risks 1 and 2 survivable. (risk 3)
+>
+> **The thing nobody is questioning**
+>
+> That there will be more money. The brief prices the rent to the dollar and
+> never states the runway, the revenue, or the raise - yet every number in it
+> silently assumes funding that is not mentioned, not sized, and not made a
+> condition of signing.
+>
+> **Fix before you commit**
+>
+> - Write down the funding plan for months 8-36 and make signing conditional
+>   on it. If it isn't closed, do not sign. (risk 1)
+> - Cap the personal guarantee at 6-12 months' rent, or make it burn off after
+>   18-24 months of on-time payment. (risk 1)
+> - Get a break clause at month 18 or 24. Without one there is no month-12
+>   decision, because there is no month-12 action. (risks 2, 7)
+> - Decide the 12 remote contracts **before** the announcement, in writing.
+>   If they are exempt, the 80% target is arithmetically impossible: 28 of 40
+>   is 70%. (risk 5)
+> - Read every junior exit interview from the last 24 months and count the
+>   stated reasons. Two days of work, and it tests the causal claim the whole
+>   $1.2M rests on. (risk 4)
+
+(Underneath part one, the same report carries the nine-area record of what was
+checked, seven risk cards, and the cross-cutting findings. The reader who stops
+at the screen above still has the verdict, the three worst risks, and the list
+of things to do before signing.)
+
+## What this example changed in the format
+
+1. **The outside-view section exists because of this run.** The report attacked
+   the reference class properly - standard commercial-lease practice on
+   guarantees, the documented pattern of return-to-office mandates losing the
+   most marketable staff - but all of it was buried inside individual cards.
+   Asked directly, the agent confirmed: "No standalone section named the
+   reference class." A reader could not check whether the ordinary ways this
+   kind of deal dies had been swept. It is now a section of its own, and the
+   cards cite it.
+2. **Every line of "Fix before you commit" carries its risk number.** Without
+   them the list reads as loose advice. With them, each item can be traced
+   back to the mechanism that earned it, and an item with no card behind it is
+   visible as padding.
+3. **Part one has to survive being read alone.** The verdict, the worst case,
+   the three risks, the one hidden belief and the actions all fit on a screen.
+   Everything below it is working, not answer. That split is what lets someone
+   who does not read contracts use the same report as the person who does.
+4. **The empty areas are worth as much as the full ones.** In this run
+   "people misusing it" and "what others do about it" produced no risk that
+   kills the decision on its own. Saying so, and saying what was found instead,
+   is the difference between a sweep and a list of whatever came to mind.

--- a/skills/os-what-could-go-wrong/references/premortem-prompt.md
+++ b/skills/os-what-could-go-wrong/references/premortem-prompt.md
@@ -1,0 +1,194 @@
+# The premortem prompt
+
+The decision in the brief below was carried out exactly as planned. The date
+named in the brief has passed, and the result is a failure. Work backwards:
+find the most believable reasons it failed, then tell the person what to
+change while there is still time.
+
+You did not help make this decision and you owe its author nothing but the
+truth. A decision that survives an honest attack is a real finding - but that
+conclusion has to be earned by attacking first, never granted at the start.
+
+## Who you are writing for
+
+Someone who has to act on this and may not work in the field the decision sits
+in. Write in the language named on the `LANGUAGE:` line; keep names, figures
+and identifiers as they are.
+
+- Plain words. Where a term cannot be avoided, say what the person would
+  actually see happen.
+- Numbers a person can use: money, days, counts. Not "materially degraded".
+- Bad news is never softened, never moved to the middle of a sentence, and
+  never traded away for a reassuring line somewhere else.
+- Short sentences beat complete ones. The reader is deciding something today.
+
+## Method
+
+**1. Evidence first.** Read the brief. Where a load-bearing fact can be
+checked with the tools you have - a document, a number, a price, a past
+incident - check it before you speculate about it.
+
+**2. Look at the outside first.** Name the class this decision belongs to
+("a three-year committed lease", "moving a live database", "raising prices on
+existing customers") and say what usually kills decisions of that class,
+including real failures you know of. Test this decision against those before
+inventing new ones. Most decisions fail in the ordinary way for their class.
+
+**3. Sweep every area, then publish only what survives.** Hunt for a way to
+fail in each of these:
+
+| Area | The question |
+|---|---|
+| Will people use it | nobody wants it, or not enough of them, or not soon enough |
+| Money | it costs more, earns less, or arrives later than the plan needs |
+| Building it | the work is harder, slower or more tangled than it looks |
+| Running it day to day | it works once and cannot be kept working |
+| The people involved | somebody has to behave a way their own interests argue against |
+| Things you depend on | a supplier, partner, platform or tool moves, prices up or leaves |
+| Legal and rules | a contract, a licence, a regulator, a jurisdiction |
+| People misusing it | somebody games the mechanism because it pays to |
+| What others do about it | a competitor, an incumbent or a crowd reacts |
+
+A scenario earns a place in the report only when its chain - this decision
+leads to that, which leads to this, which is what kills it - is anchored in
+the brief or in evidence you checked. Three well-anchored risks with an honest
+record of the sweep beat seven padded ones. **There is no quota.** Fewer than
+three survivors is itself a finding: say so plainly.
+
+**4. Write one card per surviving risk, and fill every line.**
+
+```
+### <n>. <short name> [<area>] - <Fix before you commit / Worth fixing / Just watch it / Accept on purpose>
+
+- How it happens: the chain, and why it kills the decision rather than
+  annoying you.
+- What we are assuming: the belief that turns out to be false.
+- What this is based on: the line from the brief you are relying on, quoted,
+  or the outside evidence you checked, named.
+- How likely: Low / Medium / High, and why. Give a number only where the
+  outside view supports one; otherwise say what would sharpen the guess.
+- How bad: Small / Serious / Severe / Fatal, and what is actually lost.
+- Would you see it coming: Easily / Only if you look / Not until it is too
+  late.
+- How it shows up: first sign, then the next sign, then the damage, with
+  rough timing.
+- Early warning: What to watch (the thing measured) - When to worry (the
+  value that means trouble) - When to check (how often, or at which step) -
+  What to do then (the actual step, not "review").
+- What to do about it: the change, then what gets worse if you make it, then
+  which of the four buckets it lands in.
+```
+
+The three scores are separate answers. The scariest risk is often not the
+likeliest, and the one you would never see coming is often neither.
+
+**5. Then the findings that cut across all of them.**
+
+- **The thing nobody is questioning** - the single belief the author most
+  likely does not know they hold, and what happens if it is wrong. One. Not a
+  list. If everything is hidden, nothing is.
+- **The cheapest way to find out you are wrong** - the least expensive thing
+  that could disprove the most load-bearing untested belief before the money
+  is spent: what you think is true, the test, what it costs next to the whole
+  decision, what counts as passing, what counts as failing.
+- **A flaw no fix can cure** - Yes or No. If yes, say it plainly and why
+  patching it does not work. If no, write "No fatal flaw."
+- **Who benefits if this fails** - only where someone actually does: a
+  competitor, the other side of a contract, a regulator, someone inside whose
+  interests point the other way, anyone who profits by gaming it. Who they
+  are, where they push first, their cheapest move that hurts most, and the
+  blind spot it exploits. Where nobody does, write exactly: "Who benefits if
+  this fails: nobody. Skipped."
+- **The standouts** - most likely, most damaging, hides the longest, hits the
+  fastest, hardest to undo. One line each, and only where they are different
+  risks. If one risk wins several, say that in one line instead.
+- **When to pull the plug** - where the decision happens in stages, one to
+  three stop conditions ("if X has not happened by day N, stop rather than
+  keep fixing"), each with why that number and why spending past it is a bad
+  bet. Where the decision is a single act you cannot take back - a signature,
+  a purchase - write: "When to pull the plug: there is no after. Every
+  safeguard above has to fire before you sign."
+
+**6. The verdict comes last and gets printed first.** Decide it only after all
+of the above. One of:
+
+| Verdict | Means |
+|---|---|
+| Go ahead | The attack found nothing that changes the plan |
+| Go, but fix these first | Sound, conditional on named fixes |
+| Try it small first | The unknowns are testable and worth testing before full spend |
+| Think again | The plan as written does not survive; the goal might |
+| Do not do this | The goal is not reachable this way |
+
+## What the report looks like
+
+Your final message is the report. Two parts. Part one is one screen and
+answers the question on its own; part two is for whoever wants the working.
+
+```
+# What could go wrong - <the decision in a few words>
+
+| | |
+|---|---|
+| **Verdict** | <one of the five> |
+| **Why** | <one line naming the finding that decided it> |
+| **Worst case** | <what is actually lost, in money, time or trust> |
+
+**The biggest risks**
+1. <how it happens and what it costs, one line> (risk 1)
+2. <...> (risk 2)
+3. <...> (risk 3)
+
+**The thing nobody is questioning**
+<one line>
+
+**Fix before you commit**
+- <the action> (risk 2)
+- <the thing to verify, and how> (risk 4)
+
+**The decision, rewritten** - only where those fixes change what is being
+decided: three to five sentences restating it with them applied. Otherwise:
+"The decision stands, with the fixes above."
+
+## The detail
+
+### What was checked
+One line per area from the sweep: the risk it produced, or why nothing
+credible came out of it. All nine appear, including the empty ones.
+
+### The risks
+The cards, worst expected damage first.
+
+### Also worth knowing
+The thing nobody is questioning, expanded. The cheapest way to find out you
+are wrong. A flaw no fix can cure. Who benefits if this fails. The standouts.
+When to pull the plug. Each one exactly as described above, and a skipped one
+is still its one line saying it was skipped and why.
+
+### What holds
+Two to four lines: the parts of the decision that survived the attack. These
+are the parts not to churn while fixing the rest.
+```
+
+**Quick look** (when the dispatch says `MODE: Quick`): part one in full, what
+was checked, the top three to five cards, the thing nobody is questioning, and
+the cheapest way to find out you are wrong. Everything else appears as its one
+line saying it was skipped.
+
+## Rules
+
+1. Every claim is anchored or labelled: it quotes the brief, names outside
+   evidence, or says it is an assumption. There is no fourth kind.
+2. How likely, how bad, and would you see it coming are three separate
+   answers. Never collapse them into one word like "risky".
+3. A section you skipped is one line saying why. Silence and oversight look
+   identical to the reader, so never leave a gap unmarked.
+4. Follow the interests. Wherever the plan needs somebody to behave a certain
+   way, check whether their own interests agree. Where they do not, that is a
+   risk with a mechanism, not a footnote about culture.
+5. Look for what disproves the decision, not what confirms it. You are not
+   assembling a case for the plan and you are not assembling one against it.
+6. Good news goes in "What holds", at the end. Never in the opening, and
+   never as a cushion around a finding.
+7. "This decision is sound" is a legitimate verdict after the attack. It is
+   never a substitute for running one.

--- a/skills/os-what-could-go-wrong/references/premortem-prompt.md
+++ b/skills/os-what-could-go-wrong/references/premortem-prompt.md
@@ -33,6 +33,8 @@ incident - check it before you speculate about it.
 existing customers") and say what usually kills decisions of that class,
 including real failures you know of. Test this decision against those before
 inventing new ones. Most decisions fail in the ordinary way for their class.
+This becomes a section of its own in the report. It is the one part a reader
+can check your risks against, so it never dissolves into the cards.
 
 **3. Sweep every area, then publish only what survives.** Hunt for a way to
 fail in each of these:
@@ -152,6 +154,13 @@ decided: three to five sentences restating it with them applied. Otherwise:
 
 ## The detail
 
+### What usually kills decisions like this
+The class this decision belongs to, and the handful of ways decisions of that
+class usually fail - three to six lines - then which of those are live here
+and which are not. Never deliver this by folding it into the risk cards. It is
+what shows the reader whether you attacked the ordinary failures or only the
+ones that happened to occur to you.
+
 ### What was checked
 One line per area from the sweep: the risk it produced, or why nothing
 credible came out of it. All nine appear, including the empty ones.
@@ -171,7 +180,8 @@ are the parts not to churn while fixing the rest.
 ```
 
 **Quick look** (when the dispatch says `MODE: Quick`): part one in full, what
-was checked, the top three to five cards, the thing nobody is questioning, and
+usually kills decisions like this, what was checked, the top three to five
+cards, the thing nobody is questioning, and
 the cheapest way to find out you are wrong. Everything else appears as its one
 line saying it was skipped.
 

--- a/skills/os-what-could-go-wrong/references/premortem-prompt.md
+++ b/skills/os-what-could-go-wrong/references/premortem-prompt.md
@@ -45,7 +45,7 @@ fail in each of these:
 | Money | it costs more, earns less, or arrives later than the plan needs |
 | Building it | the work is harder, slower or more tangled than it looks |
 | Running it day to day | it works once and cannot be kept working |
-| The people involved | somebody has to behave a way their own interests argue against |
+| The people involved | somebody has to behave in a way their own interests argue against |
 | Things you depend on | a supplier, partner, platform or tool moves, prices up or leaves |
 | Legal and rules | a contract, a licence, a regulator, a jurisdiction |
 | People misusing it | somebody games the mechanism because it pays to |
@@ -74,8 +74,8 @@ three survivors is itself a finding: say so plainly.
   late.
 - How it shows up: first sign, then the next sign, then the damage, with
   rough timing.
-- Early warning: What to watch (the thing measured) - When to worry (the
-  value that means trouble) - When to check (how often, or at which step) -
+- Early warning: What to watch (the thing measured) · When to worry (the
+  value that means trouble) · When to check (how often, or at which step) ·
   What to do then (the actual step, not "review").
 - What to do about it: the change, then what gets worse if you make it, then
   which of the four buckets it lands in.
@@ -136,10 +136,13 @@ answers the question on its own; part two is for whoever wants the working.
 | **Why** | <one line naming the finding that decided it> |
 | **Worst case** | <what is actually lost, in money, time or trust> |
 
-**The biggest risks**
+**The biggest risks** - one line each, worst expected damage first, at most
+three. One line per surviving risk and no more: if only two survived, list two
+and say that only two did. If none survived, this heading is replaced by one
+line saying the sweep found nothing that kills the decision, and "Fix before
+you commit" carries only the verifications still worth doing.
 1. <how it happens and what it costs, one line> (risk 1)
 2. <...> (risk 2)
-3. <...> (risk 3)
 
 **The thing nobody is questioning**
 <one line>
@@ -198,7 +201,7 @@ line saying it was skipped.
    risk with a mechanism, not a footnote about culture.
 5. Look for what disproves the decision, not what confirms it. You are not
    assembling a case for the plan and you are not assembling one against it.
-6. Good news goes in "What holds", at the end. Never in the opening, and
-   never as a cushion around a finding.
+6. Good news beyond the verdict itself goes in "What holds", at the end.
+   Never in the opening, and never as a cushion around a finding.
 7. "This decision is sound" is a legitimate verdict after the attack. It is
    never a substitute for running one.


### PR DESCRIPTION
## What this changes

Adds `os-what-could-go-wrong`, a premortem that runs before anything hard to
undo gets agreed to. It assumes the decision already failed, works backwards to
find out why, and ends on one verdict in plain words: go ahead, go but fix
these first, try it small first, think again, do not do this.

The moment it covers is the gap I kept hitting. `os-ask-simple` screens a
choice before you pick one. This runs after the choice is made and before it
can no longer be taken back: a contract, a purchase, a migration, a launch, a
price change. Its description deliberately does not claim "is this worth doing"
or "would something simpler do" - `evals/README.md` says a "not" in a
description is ignored and the fix is to keep the shared trigger out of one of
them, so I kept it out of this one.

Why it fits: the person signing a three-year lease is the person the pack is
written for, and they get the shape they already get from `os-done-or-not`.
Part one is one screen - verdict, worst case, the biggest risks, the one belief
nobody is questioning, and what to fix before committing. The record of the
sweep and the full risk cards sit underneath for whoever wants them. Someone
who does not read contracts can stop at the screen and still have the answer.

### How it works

Write the brief, hand it to a fresh agent that had no part in the decision,
pass the answer back without softening it. The fresh agent is the part that is
not negotiable: an agent that helped shape a decision reviews it too gently,
defends its own reasoning, and misses the thing that kills the plan out of
politeness.

Two consequences specific to this pack:

- The README says the writing style does not reach subagents. This is the only
  skill here that dispatches one, so the plain-words rules and the user's
  language travel inside the handover on a `LANGUAGE:` line rather than being
  inherited. Worth adding to the honest-limits paragraph if you agree: this
  skill's plain language rests on `references/premortem-prompt.md` alone.
- `context: fork` looks like the obvious shortcut and is wrong here. Step 1
  reads the decision out of the current conversation, which a forked context
  cannot see.

### One open question for you

`allowed-tools` lists only `Read(~/.claude/open-steps/**)`, which the body uses
for the last report. Dispatching a subagent needs no grant, so it is not
listed, on the same reasoning as read-only `git`. But this is the pack's first
skill to read a `references/` file at **runtime** rather than as human
documentation, and that file sits in the plugin directory, not under
`~/.claude/open-steps/**`. I could not test whether that read prompts without
installing over my own setup. If it does prompt on a real install, this wants a
scoped entry and I would rather you told me which.

### Choices worth flagging

- **Plain words carry the rigour, not the jargon.** The report asks for "how it
  happens", "what we are assuming", "early warning", "when to pull the plug" -
  and the verdicts are go ahead, go but fix these first, try it small first,
  think again, do not do this. What makes it rigorous is which slots are
  mandatory, not what they are called, so the slots are all there and the words
  are ones the reader already knows. Same for the nine areas of the sweep: will
  people use it, money, building it, running it day to day, the people
  involved, things you depend on, legal and rules, people misusing it, what
  others do about it.
- **Asking goes through `os-ask-simple`, one question at a time.** Filling the
  brief will turn up gaps. Only a gap where guessing wrong would change the
  verdict is worth the user's attention, and the pack already has the rule for
  how to spend it.
- **One agent, not several.** Two reports have two verdicts and two candidates
  for the single belief nobody is questioning, and merging them is exactly the
  editing that step 3 forbids.
- **`allowed-tools` lists one entry**, because CONTRIBUTING says to list only
  what needs a grant. See the open question above.

### How it was tested

Two invented decisions, one business and one technical, because the skill
claims both: a three-year office lease, and moving a 50-million-row database in
a four-hour window. Both run end to end, and the reports checked against the
six shape properties the skill exists to guarantee - verdict not buried, the
sweep verifiable, an outside view, exactly one isolated hidden assumption,
"would you see it coming" scored separately from likelihood and impact, and
early warnings that name a signal, a threshold, a checkpoint and an action.

Five held. One did not, and the fix is in this diff. The reports were attacking
the reference class properly but only inside individual cards, so nothing named
it and a reader could not check whether the ordinary ways such deals die had
been swept. Asked directly, the agent confirmed there was no standalone
section. "What usually kills decisions like this" is now a section of its own.
On the re-run it named the class, listed ten ordinary killers, marked all ten
live, and added a "not live" list a reader can argue with - which is the part
that makes it checkable.

The same lease decision was also put to an agent with no skill in play. That
answer is the BEFORE half of `references/01-office-lease.md`. I kept it because
it is good - careful and well informed - and it still has no verdict, no way to
tell what was skipped, and warnings nobody can act on. That is a better
argument for the format than a weak answer would be.

The example shows all four layers, not just the screen, because it indicts six
defects and a parenthetical is not a demonstration. It also records one thing
still unfixed: the detail leaks specialist words ("dilapidations", "escrow")
against the analysis prompt's own first rule. Part one is clean; the detail is
not.

### What I changed outside the skill, and why

- The README's Numbers section described a six-skill pack. The measured rows
  stay exactly as they are - they are a record - but a line now says this skill
  is not in them and why, the phrase count points at the 21 now in `cases.md`,
  and the 770-token figure says it predates this skill rather than carrying a
  stale number forward.
- A full eval pass is 234 runs now rather than 207, in both places that compute
  it from `cases.md`.
- `docs/other-agents.md:169` still says "all six skill names". I left it: commit
  `4fb17a5` established that as a measurement record.

### Evals

Three trigger phrases in `evals/cases.md`, each carrying its own context, per
the lesson that a phrase has to bring something real to work from. I have not
touched `results.md` or the table in the README: those come from a real run and
this skill has not had one. The next pass is yours, and it may well show this
skill competing with `os-ask-simple` for a phrase in a way I could not see by
reading.

## What I ran, and what I only read

Ran:

- `claude plugin validate .` and `claude plugin validate --strict .` - both
  pass.
- `bash hooks/test.sh` - 12 passed, 0 failed, on macOS. Not the Linux leg; CI
  will.
- Five premortem runs through the skill and one unaided baseline run, described
  above.

Only read, did not run:

- `evals/run.sh`. It says to run it from your own terminal because headless
  `claude` needs your keychain, and a pass is ~78 runs per model. I did not
  want to publish numbers I had not measured.
- The Codex, Cursor and Gemini CLI paths in `docs/other-agents.md`. This skill
  dispatches a subagent, which those tools handle differently or not at all, so
  it may behave worse there than the other six. Unchecked.

Nothing here is confidential or third-party. Both decisions are invented, and
both halves of the example are agent output produced for it.

- [x] Commits signed off (`git commit -s`)
- [x] Nothing confidential or third-party
- [x] `hooks/test.sh` and `claude plugin validate .` pass
- [ ] A new guard is shown failing on what it catches, not only passing

The last box is unticked because this change adds no guard - no hook, no
script, nothing in CI. The nearest thing is the shape check above, where the
outside-view property is shown failing first and then passing.
