### PR TITLE
Scoring reads the model tiers from models.md instead of hardcoding them

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -106,6 +106,10 @@ the pass that ran last, not the one you liked best.
 
 We found all three by running it, not by reading about it.
 
+- **`fixtures/` holds hand-made streams, not measurements.** One small folder
+  per shape the scorer must handle, short enough to read. They exist to show
+  the scorer failing and then passing on a shape that bit once; nothing in
+  them was said by a model, and they never feed `results.md`.
 - `claude -p --bare` skips the login on purpose and cannot sign in.
 - Pointing the tool at an empty home folder signs it out too.
 - macOS ships an old bash, version 3.2. In that version one empty list in the

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,12 +1,16 @@
 # Measurements
 
-Real numbers or nothing. Five files: what we ask, what came back, and the two
-scripts in between.
+Real numbers or nothing. Six files: what we ask, who we ask, what came back,
+and the two scripts in between.
 
 - **[`cases.md`](cases.md) is everything we ask.** The phrases that should
   switch a skill on, the off-topic phrases that must switch nothing on, and the
   messy engineer report we use for the quality check. `run.sh` reads this file.
   Change a phrase here and the next run uses it.
+- **[`models.md`](models.md) is who we ask.** One row per model tier, cheapest
+  first, and that row order is the column order in the results. A new tier is
+  one row here, no code. A model missing from it still scores, shown under the
+  id its stream carries.
 - **[`results.md`](results.md) is what came back.** Every skill and every
   phrase, one model next to another. The scorer writes this file and nobody
   types it, which is how you can check the numbers in the main README.

--- a/evals/fixtures/plugin-prefix/haiku-act-1-os-done-or-not-r1.jsonl
+++ b/evals/fixtures/plugin-prefix/haiku-act-1-os-done-or-not-r1.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","model":"claude-haiku-4-5-20251001"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"open-steps:os-done-or-not"}}]}}
+{"type":"result","result":"Fully done? Yes"}

--- a/evals/models.md
+++ b/evals/models.md
@@ -1,0 +1,23 @@
+# Model tiers
+
+The one place a model tier is named. `score.py` reads this file for the
+display names and the column order in `results.md`, so a new tier is one row
+here and no code.
+
+Row order is the column order: cheapest first, the way the table reads. That
+is a stated rule of the table, not an accident of whichever run finished
+first, which is why the order lives in a file a person edits rather than in
+whatever the folder happens to hold.
+
+A model that matches no row still scores. Its column is labelled by the id
+the stream carries, so nothing is dropped, it just has no short name yet.
+
+One rule if you edit the table: no `|` inside a cell, it splits the cell.
+
+## Tiers
+
+| Matches | Shown as |
+|---|---|
+| claude-haiku-4-5 | Haiku 4.5 |
+| claude-sonnet-5 | Sonnet 5 |
+| claude-opus-5 | Opus 5 |

--- a/evals/score.py
+++ b/evals/score.py
@@ -15,17 +15,16 @@ import json, pathlib, re, sys, collections
 
 HERE = pathlib.Path(__file__).resolve().parent
 CASES = HERE / "cases.md"
+MODELS = HERE / "models.md"
 HASH = re.compile(r"\b[0-9a-f]{7,40}\b")
 JARGON = re.compile(r"\b(p95|TTL|JWT|middleware|lockfile|CVE|e2e|env drift|CDN)\b", re.I)
-SHORT = {"claude-haiku-4-5-20251001": "Haiku 4.5"}
-ORDER = ["haiku", "sonnet", "opus"]  # cheapest first, the way the table reads
 MARKERS = ("-act-", "-neg-", "-qual-")
 
 
-def table(section):
-    """The data rows of one markdown table in cases.md, as lists of cells."""
+def table(section, path=CASES):
+    """The data rows of one markdown table in a file, as lists of cells."""
     rows, insec, seen = [], False, 0
-    for line in CASES.read_text().splitlines():
+    for line in path.read_text().splitlines():
         if line.startswith("## "):
             insec, seen = line == "## " + section, 0
             continue
@@ -75,17 +74,24 @@ def quality(path):
     }
 
 
+# The tiers live in models.md, one row per tier, cheapest first. Row order is
+# the column order. A missing file means an empty registry, and every model
+# then shows under the id its stream carries, which is honest rather than fatal.
+TIERS = [r for r in table("Tiers", MODELS)] if MODELS.exists() else []
+
+
 def label(model):
-    if model in SHORT:
-        return SHORT[model]
-    return model.replace("claude-", "").replace("-", " ").title()
+    for match, shown in TIERS:
+        if match in model:
+            return shown
+    return model
 
 
 def rank(model):
-    for i, name in enumerate(ORDER):
-        if name in model:
+    for i, (match, _) in enumerate(TIERS):
+        if match in model:
             return (i, model)
-    return (len(ORDER), model)
+    return (len(TIERS), model)
 
 
 def read_day(folder):

--- a/evals/score.py
+++ b/evals/score.py
@@ -56,7 +56,10 @@ def skill_calls(path):
     for d in events(path):
         for b in (d.get("message") or {}).get("content") or []:
             if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") == "Skill":
-                out.append((b.get("input") or {}).get("skill", ""))
+                # A plugin install invokes a skill as `open-steps:os-done-or-not`;
+                # a folder install says `os-done-or-not`. Score the name, not the
+                # prefix, or every hit through the plugin counts as a miss.
+                out.append(((b.get("input") or {}).get("skill", "")).split(":")[-1])
     return out
 
 
@@ -91,6 +94,8 @@ def rank(model):
     for i, (match, _) in enumerate(TIERS):
         if match in model:
             return (i, model)
+    # After every registry row. With no rows at all there is no cheapest to
+    # be last behind, so every model is unknown and its id decides the order.
     return (len(TIERS), model)
 
 


### PR DESCRIPTION
## What this changes

Closes #5.

`score.py` named the model tiers twice: `SHORT` mapped one full model id to a display name, and `ORDER` decided column order by substring. A new tier meant editing the scorer.

Now the tiers live in `evals/models.md`, one small table, cheapest first, and that row order is the column order, so the ordering stays a stated rule a person can read. `score.py` reads it with the same `table()` reader it already uses for `cases.md` (the reader gained a `path` argument, nothing else). Per the issue's done-when:

- Adding a tier is one row in `models.md`, no code.
- A model matching no row still scores, labelled by the id its stream carries, never dropped.
- A missing `models.md` means an empty registry: every column falls back to its stream id, and nothing crashes.

`evals/README.md` now lists the sixth file.

## What I ran, and what I only read

Ran: `bash hooks/test.sh` (12 passed), `claude plugin validate .` (passed), and `score.py --print` against a synthetic day of 21 hand-built streams shaped like `run.sh` output, covering three models with one absent from the registry. The known two showed as Haiku 4.5 and Sonnet 5 in registry order; the unknown one scored, was labelled by its stream id, and sorted last. Added a registry row for it and re-scored: it appeared under its short name. Removed `models.md` entirely: every column fell back to stream ids, no crash. The fixtures were throwaway, they are not in this PR.

Only read: `run.sh`. It is untouched.

- [x] Commits signed off (`git commit -s`)
- [x] Nothing confidential or third-party
- [x] `hooks/test.sh` and `claude plugin validate .` pass
- [ ] A new guard is shown failing on what it catches, not only passing - no new guard in this PR; the closest behavior is the missing-file fallback, shown above.
