### PR TITLE
The README summary table is written by score.py, not copied by hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ full on 2026-08-29, the day the seventh skill landed.
 
 ![Activation per skill on Haiku 4.5, Sonnet 5 and Opus 5](assets/activation.svg)
 
+<!-- numbers: score.py writes this table, edit the prose but not these rows -->
+
 | Skill | Haiku 4.5 | Sonnet 5 | Opus 5 |
 |---|---|---|---|
 | `os-check-work` | 9/9 | 9/9 | 9/9 |
@@ -194,6 +196,8 @@ full on 2026-08-29, the day the seventh skill landed.
 | `os-step-by-step` | 4/9 | 9/9 | 9/9 |
 | **All 21 phrases** | **87%** | **95%** | **100%** |
 | Fired on an off-topic question | 1/9 | 0/9 | 0/9 |
+
+<!-- numbers: end -->
 
 The honest reading, because the misses matter more than the score.
 

--- a/README.md
+++ b/README.md
@@ -185,10 +185,12 @@ full on 2026-08-29, the day the seventh skill landed.
 
 <!-- numbers: score.py writes this table, edit the prose but not these rows -->
 
+Measured on 2026-08-29.
+
 | Skill | Haiku 4.5 | Sonnet 5 | Opus 5 |
 |---|---|---|---|
-| `os-check-work` | 9/9 | 9/9 | 9/9 |
 | `os-whats-next` | 9/9 | 9/9 | 9/9 |
+| `os-check-work` | 9/9 | 9/9 | 9/9 |
 | `os-what-could-go-wrong` | 9/9 | 9/9 | 9/9 |
 | `os-ask-simple` | 9/9 | 8/9 | 9/9 |
 | `os-done-or-not` | 9/9 | 7/9 | 9/9 |

--- a/evals/README.md
+++ b/evals/README.md
@@ -50,6 +50,17 @@ day holds every model you want, write the table:
 python3 evals/score.py ~/.claude/open-steps/evals/2026-08-24
 ```
 
+That writes `evals/results.md`. The summary table on the front page is a
+separate, deliberate step, and the block it writes carries the day it came
+from:
+
+```bash
+python3 evals/score.py --readme ~/.claude/open-steps/evals/2026-08-24
+```
+
+Scoring a partial day or a foreign branch without the flag leaves the main
+README exactly as it was.
+
 ## How to read the numbers fairly
 
 The runs happen on a machine where the pack is installed and working. The

--- a/evals/score.py
+++ b/evals/score.py
@@ -16,6 +16,9 @@ import json, pathlib, re, sys, collections
 HERE = pathlib.Path(__file__).resolve().parent
 CASES = HERE / "cases.md"
 MODELS = HERE / "models.md"
+README = HERE.parent / "README.md"
+MARK_A = "<!-- numbers: score.py writes this table, edit the prose but not these rows -->"
+MARK_B = "<!-- numbers: end -->"
 HASH = re.compile(r"\b[0-9a-f]{7,40}\b")
 JARGON = re.compile(r"\b(p95|TTL|JWT|middleware|lockfile|CVE|e2e|env drift|CDN)\b", re.I)
 MARKERS = ("-act-", "-neg-", "-qual-")
@@ -165,6 +168,54 @@ def ordered_skills(runs):
     return [s for s in order if s in tested] + sorted(tested - seen)
 
 
+def readme_table(runs):
+    """The summary table the main README shows. Best skill first and the
+    misses last, because the prose under it reads the misses as the important
+    part. Ties are broken by the order cases.md tests the skills, so the sort
+    is a stated rule, not an accident of the run."""
+    models = sorted(runs, key=rank)
+    cols = [runs[m] for m in models]
+    head = " | ".join(label(m) for m in models)
+    order = ordered_skills(runs)
+
+    def hits(s):
+        return sum(r["skill"].get(s, [0, 0, 0])[0] for r in cols)
+
+    out = [f"| Skill | {head} |", "|" + "---|" * (len(cols) + 1)]
+    for s in sorted(order, key=lambda s: (-hits(s), order.index(s))):
+        cells = " | ".join(f"{r['skill'].get(s, [0, 0, 0])[0]}/{r['skill'].get(s, [0, 0, 0])[1]}" for r in cols)
+        out.append(f"| `{s}` | {cells} |")
+    phrases = len({i for r in cols for i in r["phrase"]})
+    tot = []
+    for r in cols:
+        h = sum(v[0] for v in r["skill"].values())
+        n = sum(v[1] for v in r["skill"].values())
+        tot.append(f"**{100 * h // max(n, 1)}%**")
+    out.append(f"| **All {phrases} phrases** | " + " | ".join(tot) + " |")
+    out.append("| Fired on an off-topic question | "
+               + " | ".join(f"{r['neg'][0]}/{r['neg'][1]}" for r in cols) + " |")
+    return "\n".join(out)
+
+
+def update_readme(runs):
+    """Rewrite the summary table in the main README, between its two markers.
+    Only the table: the prose and the figure around it belong to a person.
+    No markers means no touch and a word about it, never a guess at where
+    the table was supposed to go."""
+    if not README.exists():
+        return "README.md not found, left alone"
+    text = README.read_text()
+    if MARK_A not in text or MARK_B not in text:
+        return "README.md has no table markers, left alone"
+    a = text.index(MARK_A) + len(MARK_A)
+    b = text.index(MARK_B)
+    new = text[:a] + "\n\n" + readme_table(runs) + "\n\n" + text[b:]
+    if new == text:
+        return "README.md already matches"
+    README.write_text(new)
+    return "wrote the summary table into README.md"
+
+
 def report(folder, runs):
     """The whole day as one page: per skill, per phrase, then the quality arms."""
     models = sorted(runs, key=rank)
@@ -228,5 +279,7 @@ text = report(folder, runs)
 if not show_only:
     out = HERE / "results.md"
     out.write_text(text)
-    print(f"wrote {out}\n")
+    print(f"wrote {out}")
+    print(update_readme(runs))
+    print()
 print(text)

--- a/evals/score.py
+++ b/evals/score.py
@@ -3,9 +3,13 @@
 
     python3 evals/score.py --print ~/.claude/open-steps/evals/2026-08-24
     python3 evals/score.py ~/.claude/open-steps/evals/2026-08-24
+    python3 evals/score.py --readme ~/.claude/open-steps/evals/2026-08-24
 
-The first prints the table, the second also writes it to evals/results.md. The
-transcripts sit outside the repository, one folder per day, holding every model
+The first prints the table, the second also writes it to evals/results.md, the
+third also rewrites the summary table in the main README, dated with the day
+it came from. That last one is a flag and not a side effect because partial
+days and foreign branches get scored all the time, and none of them belong on
+the front page by accident. The transcripts sit outside the repository, one folder per day, holding every model
 that ran that day. Which model a stream came from is read out of the stream
 itself, so a renamed file cannot mislabel a column. Activation comes from the
 tool-call log, report quality from plain string rules. The phrases come from
@@ -197,11 +201,12 @@ def readme_table(runs):
     return "\n".join(out)
 
 
-def update_readme(runs):
-    """Rewrite the summary table in the main README, between its two markers.
-    Only the table: the prose and the figure around it belong to a person.
-    No markers means no touch and a word about it, never a guess at where
-    the table was supposed to go."""
+def update_readme(folder, runs):
+    """Rewrite the summary table in the main README, between its two markers,
+    with the day it was measured on written above it, so a number can never
+    wear the prose's date. Only that block: the prose and the figure around it
+    belong to a person. No markers means no touch and a word about it, never a
+    guess at where the table was supposed to go."""
     if not README.exists():
         return "README.md not found, left alone"
     text = README.read_text()
@@ -209,11 +214,12 @@ def update_readme(runs):
         return "README.md has no table markers, left alone"
     a = text.index(MARK_A) + len(MARK_A)
     b = text.index(MARK_B)
-    new = text[:a] + "\n\n" + readme_table(runs) + "\n\n" + text[b:]
+    block = f"Measured on {folder.name}.\n\n" + readme_table(runs)
+    new = text[:a] + "\n\n" + block + "\n\n" + text[b:]
     if new == text:
-        return "README.md already matches"
+        return f"README.md already matches {folder.name}"
     README.write_text(new)
-    return "wrote the summary table into README.md"
+    return f"wrote the summary table into README.md, dated {folder.name}. The prose around it is not touched"
 
 
 def report(folder, runs):
@@ -267,10 +273,12 @@ def report(folder, runs):
     return "\n".join(out) + "\n"
 
 
-args = [a for a in sys.argv[1:] if a != "--print"]
-show_only = "--print" in sys.argv[1:]
-if len(args) != 1 or not pathlib.Path(args[0]).is_dir():
-    sys.exit("usage: score.py [--print] ~/.claude/open-steps/evals/<day>")
+flags = [a for a in sys.argv[1:] if a.startswith("--")]
+args = [a for a in sys.argv[1:] if not a.startswith("--")]
+show_only, readme = "--print" in flags, "--readme" in flags
+if (len(args) != 1 or not pathlib.Path(args[0]).is_dir()
+        or set(flags) - {"--print", "--readme"} or (show_only and readme)):
+    sys.exit("usage: score.py [--print | --readme] ~/.claude/open-steps/evals/<day>")
 folder = pathlib.Path(args[0])
 runs = read_day(folder)
 if not runs:
@@ -280,6 +288,8 @@ if not show_only:
     out = HERE / "results.md"
     out.write_text(text)
     print(f"wrote {out}")
-    print(update_readme(runs))
+    # The README is the front page. It changes on --readme only, never as a
+    # side effect of scoring a partial day or a foreign branch.
+    print(update_readme(folder, runs) if readme else "README.md not touched, --readme rewrites its table")
     print()
 print(text)


### PR DESCRIPTION
## What this changes

Closes #7.

`score.py` wrote `evals/results.md` while the summary table under **Numbers** in the README was a separate hand-kept copy. The two agree today, every per-skill row matches, so this is prevention, not a repair of a drift that does not exist.

The README's presentation is deliberate and stays. Of the two options the issue offers, this PR takes the first: the generator reproduces the README's own shape rather than the `results.md` shape. Best skill first and the misses last, because the prose underneath reads the misses as the important part; a totals row that names the phrase count and carries a bare percentage. Tied skills follow the order `cases.md` tests them, so the sort is a stated rule rather than a hand choice, and the committed table is already in that order.

Mechanics: the block sits between two HTML-comment markers and opens with `Measured on <day>.`, written from the day folder's name, so a number can never wear the prose's date. The scorer rewrites only what is between the markers, and only on `--readme`: `score.py <day>` writes `results.md` as before and prints one line saying the README was not touched. That is a flag rather than a side effect because partial days and foreign branches get scored all the time, and none of them belong on the front page by accident. Regenerating twice produces no diff (the second run says "already matches"). A README without the markers is left byte-identical, with a line saying so, never a guess at where the table was supposed to go. `--print` never writes anything, and `--print --readme` together is a usage error.

## What I ran, and what I only read

Ran: `bash hooks/test.sh` (12 passed), `claude plugin validate .` (passed). Ran the scorer in a sandbox copy of the repo against a synthetic day: without the flag the README came back byte-identical with the one-line notice; with `--readme` the dated block was written between the markers, prose and figure untouched, misses sorted last, phrase count and percentages in the README's own format; a second `--readme` run reported "already matches" with zero diff; with one marker removed the README stayed byte-identical and the message printed; `--print --readme` refused. The sandbox and fixtures are not in this PR.

Only read: the real 2026-08-29 day. I do not have those transcripts, so this PR does not regenerate the live table; it wraps the existing one in markers, adds its `Measured on` line, and puts its tied rows in the generator's order, values unchanged.

- [x] Commits signed off (`git commit -s`)
- [x] Nothing confidential or third-party
- [x] `hooks/test.sh` and `claude plugin validate .` pass
- [ ] A new guard is shown failing on what it catches, not only passing - the closest things are the missing-marker case and the `--print --readme` refusal, both shown above.
