### PR TITLE
os-ask-simple gains its worked example

### DIFF
--- a/skills/os-ask-simple/references/01-sign-in-now-or-later.md
+++ b/skills/os-ask-simple/references/01-sign-in-now-or-later.md
@@ -1,0 +1,54 @@
+# Example 1 - three questions in one, none of them answerable
+
+Source: a real session in my own analytics dashboard project, condensed. No
+client or third-party material.
+
+## What the agent asked
+
+> Should I integrate Clerk with Next.js middleware for route-level protection,
+> or defer auth and keep the deployment protection for now? If Clerk, do you
+> want the hosted sign-in page or embedded components, and should I model
+> organizations from the start in case you go multi-tenant later?
+
+Three questions stacked in one message, each assuming the answer to the one
+before it, all in the vendor's vocabulary.
+
+## `os-ask-simple`
+
+> Should the dashboard get real sign-in now, or stay behind the single
+> password it has today?
+>
+> Why it matters: today one password guards everything; real sign-in gives
+> each person their own access, which you can take away one at a time.
+> What changes later: nothing gets harder by waiting - the sign-in work is the
+> same size on the day a second person needs it.
+> Easy to undo: yes - the gate is one file and one screen; take them out and
+> the password is back.
+>
+> | Check | Answer |
+> |---|---|
+> | How long now | Roughly half a day to a day; the gate in front of every page, plus the sign-in screen in the app shell |
+> | Simpler substitute | The password already there - it does this one job today |
+> | Extra work for you later | Inviting and removing people by hand in the provider's dashboard |
+> | Harder to change later | Accounts lock to the provider's user ids; switching providers means re-mapping them |
+> | Over-engineering | Yes, today - one person uses this dashboard |
+> | Easy to undo | Yes: the gate is one file and one screen; remove them and the password is back |
+>
+> My recommendation: change nothing until a second person needs access. The
+> password does the one job sign-in would do, and the half-day is better spent
+> on the dashboard itself.
+>
+> **Sign-in?**
+> - Keep the password (Recommended) - nothing to build; add sign-in the day a second person needs in
+> - Add real sign-in now - roughly half a day to a day, then inviting people by hand
+
+## What the rewrite did
+
+| Move | Where |
+|---|---|
+| Three questions became one | hosted-vs-embedded and multi-tenant only exist after a yes - asking them first buys careless answers (rule 5) |
+| Vendor words became what the reader would see | "Clerk with middleware" → "real sign-in"; "deployment protection" → "the single password" |
+| Doing nothing was weighed, and won | rule 1 - and the one line says why it won |
+| The screen said over-engineering, plainly | one person today; the row exists to be answered yes sometimes |
+| Recommended against the more interesting build | the integration is the fun option; that was a reason for suspicion, not preference (rule 6) |
+| The picker carried the trade-offs | two options, one line each, the recommended one first and marked |


### PR DESCRIPTION
## What this changes

Part of #8, one of three.

`skills/os-ask-simple/references/01-sign-in-now-or-later.md`: a question an agent asked in my own analytics dashboard project, three vendor-vocabulary questions stacked in one message with each assuming the answer to the one before, next to the one plain question the person could answer. The light form, then the six-check screen as a table with every row answered, doing nothing weighed and winning, one marked recommendation, and the picker with a one-line trade-off per option. The closing table pins each rewrite to the rule it obeys.

Read against `SKILL.md` line by line: one question at a time (rule 5), doing nothing weighed with the reason it won (rule 1), a recommendation against the more interesting build (rule 6), "roughly" plus a range on the effort row, an over-engineering row that answers yes, a picker heading under twelve characters with labels of one to five words.

Sourcing: from my own work, condensed. Nothing confidential or third-party; the project is mine and no client is involved.

## What I ran, and what I only read

Ran: `bash hooks/test.sh` (12 passed), `claude plugin validate .` (passed). Nothing automatic checks a reference file, as the issue says, so the example was read against every rule and gotcha in its `SKILL.md` by hand, and against the shape of the three references that already exist.

Only read: the three existing examples, for shape.

- [x] Commits signed off (`git commit -s`)
- [x] Nothing confidential or third-party
- [x] `hooks/test.sh` and `claude plugin validate .` pass
- [ ] A new guard is shown failing on what it catches, not only passing - no guard in this PR, a reference file only.
