### PR TITLE
os-check-work gains its worked example

### DIFF
--- a/skills/os-check-work/references/01-accepting-a-build-session.md
+++ b/skills/os-check-work/references/01-accepting-a-build-session.md
@@ -1,0 +1,51 @@
+# Example 1 - a report that said "safe to merge", checked before believing it
+
+Source: a real accept pass in my own dashboard project, where one session
+builds and another verifies. Condensed; no client or third-party material.
+
+## What the build session reported
+
+> PR #14 is ready: the responsive card layout is done, tests are green, I
+> addressed all review comments, safe to merge.
+
+Four claims, zero numbers. Written by the party being assessed.
+
+## `os-check-work`, accept mode
+
+> I checked PR #14 against the machine, not the report.
+>
+> Claimed: tests are green. Measured: 7 of 7 checks pass - that part holds.
+> Claimed: addressed all comments. Measured: one review thread still open.
+> Claimed: ready to merge. Measured: the approval was given three commits
+> ago; the branch was pushed twice since, so it no longer covers what would
+> merge.
+> Found unclaimed: the diff touches a config file the task never asked for,
+> and no test file is in it - the green checks are the old suite passing,
+> not new coverage.
+> Not checked: how the cards look on a phone - I read the diff, not the
+> screen.
+>
+> This goes back, with the reply written:
+>
+> **To the layout session** - paste this:
+> PR #14: resolve the open thread on the card spacing, remove the unrelated
+> config change or say why it belongs here, and add a test for the
+> phone-width layout - the diff has none. Then re-request review; the old
+> approval predates your last two pushes.
+>
+> | | |
+> |---|---|
+> | **Still open** | PR #14, back with its session for the four items above |
+> | **Do this next** | nothing until it returns - the fix list is with its author |
+> | **On your word** | re-run the accept the moment it comes back |
+
+## What the pass did
+
+| Move | Where |
+|---|---|
+| Adjectives became counts | "green" → 7 of 7; "addressed" → one thread still open (rule 5) |
+| The approval was re-dated, not trusted | approved-then-pushed is the claim that dies most quietly (rule 4) |
+| The unclaimed was hunted | scope creep and missing tests are never reported - they are found |
+| The unseen was named | the layout itself went unverified, and the pass says so (rule 6) |
+| Nothing was fixed silently | fixing it here makes the checker the author of the work being checked (rule 1) |
+| The reply travels ready to paste | self-contained, names the PR and every gap, speaks as the user |


### PR DESCRIPTION
## What this changes

Part of #8, one of three.

`skills/os-check-work/references/01-accepting-a-build-session.md`: an accept pass from my own dashboard project, where one session builds and another verifies. The build session's report makes four claims and carries no number. The pass re-measures each claim at its source (the check count, the open-thread count, the approval's date against the pushes since), hunts what was never claimed (an unasked config change, no test in the diff), says what it could not check (the layout on a phone), and hands the work back with the reply written and ready to paste. It ends with the closing block, nothing after it.

Read against `SKILL.md`: claimed then measured, in that order (rule 5), state re-read rather than trusted (rule 4), nothing repaired silently (rule 1), the unverifiable named (rule 6), a reply that is self-contained and speaks as the user, a closing block that does not end on a question.

Sourcing: from my own work, condensed. Nothing confidential or third-party; the project is mine and no client is involved.

## What I ran, and what I only read

Ran: `bash hooks/test.sh` (12 passed), `claude plugin validate .` (passed). Nothing automatic checks a reference file, as the issue says, so the example was read against every rule and gotcha in its `SKILL.md` by hand, and against the shape of the three references that already exist.

Only read: the three existing examples, for shape.

- [x] Commits signed off (`git commit -s`)
- [x] Nothing confidential or third-party
- [x] `hooks/test.sh` and `claude plugin validate .` pass
- [ ] A new guard is shown failing on what it catches, not only passing - no guard in this PR, a reference file only.
